### PR TITLE
Prepare open-source readiness files

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,13 +1,31 @@
 ---
 name: Feature request
-about: Suggest an idea
+about: Suggest an improvement or new feature for Stationarr
+title: "[Feature]: "
+labels: enhancement
+assignees: ""
 ---
 
-**What problem does this solve?**
-A clear description of the use case.
+## Problem or use case
 
-**Describe the solution you'd like**
-What you want to happen.
+What problem does this solve? Who would benefit from it?
 
-**Alternatives considered**
-Any other approaches you've thought about.
+## Proposed solution
+
+Describe the solution you would like.
+
+## Alternatives considered
+
+Describe any other approaches you considered.
+
+## IPTV/legal context
+
+Does this feature involve playlists, stream URLs, provider credentials, EPG sources, logos, or third-party content?
+
+If yes, explain how it can be implemented without including or encouraging unauthorized content.
+
+## Additional context
+
+Add screenshots, mockups, examples, or technical notes if helpful.
+
+**Do not include real provider credentials, private playlist URLs, M3U URLs, EPG URLs, JWT secrets, database files, or copyrighted channel lists.**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Summary
+
+Describe what this pull request changes.
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Security improvement
+- [ ] Refactor or maintenance
+
+## Testing
+
+Describe how you tested the change.
+
+- [ ] Tested with Docker or Docker Compose
+- [ ] Tested frontend changes in a browser
+- [ ] Tested playlist import/export if relevant
+- [ ] Tested EPG/XMLTV behaviour if relevant
+
+## Security and privacy checklist
+
+- [ ] I did not include real provider credentials, private playlist URLs, M3U URLs, EPG URLs, JWT secrets, database files, or copyrighted channel lists.
+- [ ] I did not add demo data that points to unauthorized streams or paid TV content.
+- [ ] I considered whether this change affects public playlist/EPG URLs or authentication.
+- [ ] I considered whether this change affects Docker socket access or host permissions.
+
+## Screenshots
+
+Add screenshots for UI changes, if applicable.
+
+## Notes for reviewers
+
+Add anything the maintainer should pay special attention to.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+# Code of Conduct
+
+## Our pledge
+
+We want Stationarr to be a welcoming, practical, and respectful open-source project.
+
+Everyone participating in this project is expected to communicate respectfully, assume good faith, and help keep discussions focused on improving the software.
+
+## Expected behaviour
+
+Examples of positive behaviour include:
+
+- being respectful of different experience levels;
+- giving constructive feedback;
+- keeping discussions focused on the issue or pull request;
+- helping new contributors understand the project;
+- reporting bugs with enough detail to reproduce them.
+
+## Unacceptable behaviour
+
+Examples of unacceptable behaviour include:
+
+- harassment, threats, insults, or personal attacks;
+- discriminatory language or conduct;
+- repeated off-topic arguments;
+- posting illegal, pirated, or unauthorized IPTV sources;
+- posting real provider credentials, private playlist URLs, or copyrighted channel lists;
+- attempting to use the project community to request or distribute unauthorized streams.
+
+## IPTV/content rule
+
+Stationarr is a playlist and EPG management tool only. Do not use project issues, pull requests, discussions, examples, screenshots, or documentation to share or request unauthorized IPTV streams, paid channel lists, copyrighted broadcasts, provider credentials, or piracy-related resources.
+
+## Enforcement
+
+The maintainer may edit, hide, delete, or lock comments and issues that violate this code of conduct. Repeated or serious violations may result in being blocked from participating in the project.
+
+## Contact
+
+For moderation concerns, contact the maintainer at:
+
+**rroy676@gmail.com**

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,29 @@
+# Disclaimer
+
+Stationarr is a self-hosted playlist and EPG management tool. It is intended to help users organize M3U playlists, map XMLTV programme guide data, and serve edited playlist outputs to compatible media players.
+
+Stationarr does **not** provide, host, sell, distribute, promote, recommend, or endorse IPTV streams, subscriptions, copyrighted broadcasts, paid television services, channel packages, or unauthorized access to television content.
+
+Users are solely responsible for ensuring that any M3U playlists, XMLTV data, stream URLs, provider credentials, logos, metadata, or other content used with Stationarr are legally obtained and used in compliance with applicable laws, copyright rules, service agreements, and provider terms.
+
+The maintainers of Stationarr do not control, verify, endorse, or assume responsibility for any third-party content, stream URLs, playlist sources, EPG sources, or provider credentials entered into the application by users.
+
+Stationarr should not be used to access or distribute content without authorization from the rights holder or lawful provider.
+
+## No content is included
+
+This repository should not contain real IPTV provider playlists, paid channel lists, stream URLs, credentials, copyrighted programme data, or proprietary EPG feeds. Examples and screenshots should use demo data, public free-to-access sources, or placeholder values only.
+
+## User responsibility
+
+By using Stationarr, you agree that you are responsible for:
+
+- using only legally obtained playlists and EPG data;
+- respecting copyright and broadcasting rights;
+- complying with the terms of any IPTV, streaming, television, or EPG provider you use;
+- keeping your served playlist URLs, Xtream credentials, and provider credentials private;
+- complying with the laws that apply in your jurisdiction.
+
+## No legal advice
+
+This disclaimer is provided for project clarity and risk reduction. It is not legal advice.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@
 
 ---
 
-Import your M3U playlist, organise channels, match programme guide data from multiple sources, and serve a clean edited playlist directly to your IPTV player.
+Import legally obtained M3U playlists, organise channels, match XMLTV programme guide data from authorized or public sources, and serve a clean edited playlist directly to your IPTV player.
+
+Stationarr is a playlist and EPG management tool only. It does **not** provide, host, sell, distribute, promote, or recommend IPTV streams, subscriptions, copyrighted broadcasts, paid channel packages, or unauthorized access to television content. Users are responsible for ensuring that all playlists, EPG sources, provider credentials, stream URLs, logos, and metadata used with Stationarr are legally obtained and used in compliance with applicable laws and provider terms.
+
+See [DISCLAIMER.md](DISCLAIMER.md) before using or contributing to this project.
 
 ---
 
@@ -46,7 +50,7 @@ Import your M3U playlist, organise channels, match programme guide data from mul
 ## Features
 
 ### Playlist management
-- Import M3U via provider login (Xtream Codes), URL, or file upload
+- Import M3U via authorized provider login (Xtream Codes), URL, or file upload
 - Duplicate playlists or create filtered copies (by group, keyword, enabled channels)
 - Auto-refresh channels on a schedule
 - Xtream Codes API output — compatible with TiviMate, IPTV Smarters, etc.
@@ -140,6 +144,8 @@ docker compose up -d
 
 **Step 3 — Go to Settings → EPG Scraper** to add channels and run the scraper from the UI.
 
+> **Docker socket warning:** Some scraper-management workflows may require Docker socket access. Mounting `/var/run/docker.sock` gives the Stationarr container broad control over Docker on the host. Only enable it on trusted self-hosted systems. See [SECURITY.md](SECURITY.md).
+
 ---
 
 ## Quick start — Bare metal
@@ -205,6 +211,8 @@ After importing a playlist, each user gets unique URLs:
 
 Add these directly to your IPTV player (TiviMate, IPTV Smarters, Kodi, VLC, etc.)
 
+> **Privacy warning:** Hosted playlist, EPG, and Xtream URLs are bearer-style access URLs. Anyone with the URL may be able to access that output. Keep them private and rotate/regenerate credentials if exposed.
+
 ---
 
 ## Free EPG sources
@@ -249,13 +257,13 @@ Stationarr includes a built-in browser of free public EPG sources. Go to **EPG S
 ### 2. Importing channels
 
 **From a URL (M3U)**
-Open the playlist editor → click **Import → URL** → paste your provider's `.m3u` link → Fetch. Enable **Auto-refresh** in playlist settings to re-import on a schedule.
+Open the playlist editor → click **Import → URL** → paste your authorized provider's `.m3u` link → Fetch. Enable **Auto-refresh** in playlist settings to re-import on a schedule.
 
 **From a file**
-Import → File → select a local `.m3u` or `.m3u8` file.
+Import → File → select a local `.m3u` or `.m3u8` file that you are legally authorized to use.
 
 **Xtream Codes / provider login**
-Import → Xtream → enter server address, username, password. All streams are fetched via the Xtream API.
+Import → Xtream → enter server address, username, password for a provider account you are authorized to access. All streams are fetched via the Xtream API.
 
 **Organising**
 - Drag rows to reorder. Shift+click / Ctrl+click to multi-select.
@@ -308,6 +316,22 @@ Click **Serve** on any playlist to get your personal URLs:
 **VLC** — Media → Open Network Stream → paste the M3U URL.
 
 > Make sure `BASE_URL` in your `.env` points to an address reachable by your players. Use a local IP for LAN-only setups, or your public domain/IP for remote access.
+
+---
+
+## Roadmap
+
+Planned or possible improvements:
+
+- Regenerate hosted playlist and EPG slugs from the UI
+- Optional token support for served playlist and EPG URLs
+- Safer scraper-sidecar management without requiring Docker socket access
+- Docker healthcheck and improved container diagnostics
+- Automated build/test workflow with GitHub Actions
+- Import/export for individual playlists
+- Advanced duplicate detection and cleanup tools
+- Improved EPG conflict resolution and source priority controls
+- More tests around M3U parsing, XMLTV parsing, authentication, and public serve endpoints
 
 ---
 
@@ -379,6 +403,8 @@ Stationarr is free and open source, built and maintained in spare time. If it's 
 ## Contributing
 
 PRs welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+
+For security issues, please read [SECURITY.md](SECURITY.md) and do not open a public issue.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do **not** open a public GitHub issue for security vulnerabilities.
+
+Report security issues by emailing the maintainer directly:
+
+**rroy676@gmail.com**
+
+Please include as much detail as possible:
+
+- a clear description of the issue;
+- steps to reproduce the issue;
+- affected version, branch, or commit if known;
+- deployment type, such as Docker, Docker Compose, or bare metal;
+- potential impact;
+- logs, screenshots, or proof-of-concept details if safe to share;
+- any suggested fix, if known.
+
+## Supported versions
+
+Until Stationarr reaches a stable release, only the latest version on the `main` branch is supported.
+
+## Public playlist and EPG URLs
+
+Stationarr serves playlist and EPG outputs through bearer-style URLs. Anyone with access to a served URL may be able to access that playlist or EPG output. Keep these URLs private and regenerate credentials if you believe they were exposed.
+
+Do not post screenshots or logs that reveal:
+
+- provider URLs;
+- M3U playlist URLs;
+- XMLTV/EPG URLs;
+- Xtream usernames or passwords;
+- served Stationarr playlist URLs;
+- JWT secrets;
+- database files or backups.
+
+## Docker socket warning
+
+Some optional scraper-management workflows may require access to the Docker socket.
+
+Mounting `/var/run/docker.sock` into a container can give that container broad control over Docker on the host. Only enable Docker socket access on trusted self-hosted systems, and avoid exposing Stationarr to untrusted networks when this feature is enabled.
+
+If you do not need UI-managed scraper control, remove or comment out the Docker socket mount in `docker-compose.yml`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,10 @@ services:
     volumes:
       - stationarr_data:/app/data
       - scraper_shared:/app/data/scraper
-      - /var/run/docker.sock:/var/run/docker.sock
+      # Optional: enable only if you need Stationarr to control Docker-based scraper workflows.
+      # WARNING: Mounting the Docker socket gives this container broad control over Docker on the host.
+      # See SECURITY.md before enabling.
+      # - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - PORT=3000
       - JWT_SECRET=${JWT_SECRET:-changeme-set-in-env-file}


### PR DESCRIPTION
## Summary

This PR prepares Stationarr for a public open-source release by adding the missing governance, legal, safety, and contributor files, and by tightening README language around IPTV/content responsibility.

## Added

- `DISCLAIMER.md` with clear IPTV/content/legal-use positioning
- `SECURITY.md` with vulnerability reporting instructions, URL privacy notes, and Docker socket warning
- `CODE_OF_CONDUCT.md` with community rules and explicit prohibition on sharing unauthorized IPTV sources
- `.github/pull_request_template.md` with security/privacy checklist

## Updated

- `README.md`
  - clarifies that Stationarr is for legally obtained playlists and authorized/public EPG sources
  - adds disclaimer link near the top
  - adds Docker socket warning
  - adds hosted playlist/EPG URL privacy warning
  - adjusts usage language around authorized M3U/Xtream use
  - adds a roadmap section
  - adds security reporting link

- `.github/ISSUE_TEMPLATE/feature_request.md`
  - expands the template
  - adds IPTV/legal context prompt
  - warns against including private URLs, credentials, database files, or copyrighted channel lists

- `docker-compose.yml`
  - comments out the Docker socket mount by default
  - adds warning comments pointing to `SECURITY.md`

## Notes

This PR does not change application logic, except that the default Docker Compose file no longer mounts `/var/run/docker.sock` unless the user explicitly enables it. That is intentional for safer public defaults.