### PR TITLE
[codex] Fix Import M3U modal crash

### DIFF
--- a/frontend/src/pages/Editor.jsx
+++ b/frontend/src/pages/Editor.jsx
@@ -16,6 +16,7 @@ export default function Editor() {
   const toast   = useToast();
 
   const [playlist,    setPlaylist]    = useState(null);
+  const [allPlaylists, setAllPlaylists] = useState([]);
   const [channels,    setChannels]    = useState([]);
   const [epgSources,  setEpgSources]  = useState([]);
   const [allEpgCh,    setAllEpgCh]    = useState([]);
@@ -37,8 +38,9 @@ export default function Editor() {
       chApi.list(id),
       epgApi.list(),
       plApi.list(),
-    ]).then(([pl, chs, sources]) => {
+    ]).then(([pl, chs, sources, playlists]) => {
       setPlaylist(pl);
+      setAllPlaylists(playlists);
       setChannels(chs);
       setEpgSources(sources);
       // Load EPG channels for all sources that have been fetched
@@ -135,6 +137,8 @@ export default function Editor() {
     setChannels(chs);
     const pl = await plApi.get(id);
     setPlaylist(pl);
+    const playlists = await plApi.list();
+    setAllPlaylists(playlists);
   }, [id]);
 
   // Auto-match EPG


### PR DESCRIPTION
## Summary

Fixes the Import M3U button crash in the playlist editor by keeping the full playlist list in editor state and passing it into `ImportModal`.

## Root Cause

`Editor.jsx` already requested `plApi.list()` during the initial editor load, but the returned value was not captured. When the import modal rendered, it referenced `allPlaylists`, which did not exist in the component scope, causing `allPlaylists is not defined` in the browser console.

## Changes

- Add `allPlaylists` state to the editor page.
- Store the playlist list returned by the initial `Promise.all`.
- Refresh the playlist list after imports so the modal stays current for clone/import workflows.

## Validation

- Ran `npm ci` in `frontend/`.
- Ran `npm run build` successfully.
- Manually validated in the browser: clicking `Import M3U` now opens the import dialog instead of logging a console error.
