### PR TITLE
Improve EPG scraper UX when no scraper channels are configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Improved
+- EPG Scraper now reports when `channels.xml` has zero selected channels, shows clearer UI warnings, blocks manual runs with no configured channels, and returns a friendly 404 message for `/api/scraper/guide.xml` when no guide can be generated.
+
 ## [1.0.6] — 2026-05-16
 
 ### Fixed

--- a/backend/src/routes/scraper.js
+++ b/backend/src/routes/scraper.js
@@ -10,8 +10,20 @@ const DATA_DIR      = process.env.DATA_DIR || './data';
 const SCRAPER_URL   = process.env.SCRAPER_URL || 'http://epg:3000';
 const CHANNELS_PATH = process.env.SCRAPER_CHANNELS_PATH || path.join(DATA_DIR, 'scraper', 'channels.xml');
 
+function getConfiguredChannelCountFromXML() {
+  if (!fs.existsSync(CHANNELS_PATH)) return 0;
+  const xml = fs.readFileSync(CHANNELS_PATH, 'utf8');
+  const matches = xml.match(/<channel\b/g);
+  return matches ? matches.length : 0;
+}
+
 // ── Status ────────────────────────────────────────────────────────
 router.get('/status', requireAuth, async (req, res) => {
+  const enabledCount = db.prepare(
+    'SELECT COUNT(*) AS n FROM scraper_channels WHERE user_id = ? AND enabled = 1'
+  ).get(req.user.id).n || 0;
+  const configuredCount = getConfiguredChannelCountFromXML();
+
   try {
     const r = await fetch(`${SCRAPER_URL}/guide.xml`, { method: 'HEAD', timeout: 5000 });
     const guideSize = r.headers.get('content-length');
@@ -20,9 +32,20 @@ router.get('/status', requireAuth, async (req, res) => {
       url:         SCRAPER_URL,
       guide_url:   `${SCRAPER_URL}/guide.xml`,
       guide_size:  guideSize ? parseInt(guideSize) : null,
+      enabled_channel_count: enabledCount,
+      configured_channel_count: configuredCount,
+      no_channels_configured: configuredCount === 0,
     });
   } catch {
-    res.json({ online: false, url: SCRAPER_URL, guide_url: null, guide_size: null });
+    res.json({
+      online: false,
+      url: SCRAPER_URL,
+      guide_url: null,
+      guide_size: null,
+      enabled_channel_count: enabledCount,
+      configured_channel_count: configuredCount,
+      no_channels_configured: configuredCount === 0,
+    });
   }
 });
 
@@ -115,9 +138,20 @@ router.get('/sites', requireAuth, async (req, res) => {
 
 // ── Proxy guide.xml from scraper ──────────────────────────────────
 router.get('/guide.xml', requireAuth, async (req, res) => {
+  const configuredCount = getConfiguredChannelCountFromXML();
+
   try {
     const r = await fetch(`${SCRAPER_URL}/guide.xml`, { timeout: 30000 });
-    if (!r.ok) throw new Error('HTTP ' + r.status);
+    if (!r.ok) {
+      if (r.status === 404 && configuredCount === 0) {
+        return res.status(404).json({
+          error: 'No guide generated yet because no scraper channels are selected.',
+          code: 'NO_SCRAPER_CHANNELS',
+          configured_channel_count: configuredCount,
+        });
+      }
+      throw new Error('HTTP ' + r.status);
+    }
     res.setHeader('Content-Type', 'application/xml; charset=utf-8');
     r.body.pipe(res);
   } catch (e) {
@@ -205,6 +239,11 @@ router.get('/run', async (req, res) => {
   };
 
   const scraperUrl = process.env.SCRAPER_URL || 'http://epg:3000';
+  const configuredCount = getConfiguredChannelCountFromXML();
+  if (configuredCount === 0) {
+    send({ type: 'error', msg: 'No scraper channels are configured. Add and enable at least one channel before running.' });
+    return res.end();
+  }
 
   send({ type: 'log', msg: `Connecting to scraper at ${scraperUrl}...` });
 

--- a/frontend/src/pages/Scraper.jsx
+++ b/frontend/src/pages/Scraper.jsx
@@ -65,6 +65,10 @@ export default function ScraperPage() {
 
   const runScraper = () => {
     if (running) return;
+    if (status?.no_channels_configured || enabledCount === 0) {
+      toast('No scraper channels are configured. Add and enable at least one channel first.', 'warning');
+      return;
+    }
     setRunning(true);
     setRunDone(false);
     setLogs([]);
@@ -117,7 +121,10 @@ export default function ScraperPage() {
       setLogs(prev => [...prev, { type: 'done', msg: `✓ Done! Loaded ${res.loaded} channels into Stationarr EPG cache.` }]);
       load();
     } catch (e) {
-      setLogs(prev => [...prev, { type: 'error', msg: `Could not auto-fetch guide: ${e.message}` }]);
+      const friendly = e.message?.includes('NO_SCRAPER_CHANNELS')
+        ? 'No guide was generated because no scraper channels are selected. Add and enable channels, then run again.'
+        : `Could not auto-fetch guide: ${e.message}`;
+      setLogs(prev => [...prev, { type: 'error', msg: friendly }]);
     }
   };
 
@@ -165,6 +172,7 @@ export default function ScraperPage() {
 
   const scraperSource = epgSources.find(s => s.name === 'iptv-org/epg (scraper)');
   const enabledCount  = channels.filter(c => c.enabled).length;
+  const noConfiguredChannels = Boolean(status?.no_channels_configured ?? (enabledCount === 0));
   const availSites    = sites.filter(s => !country || s.countries.includes(country));
 
   return (
@@ -197,8 +205,8 @@ export default function ScraperPage() {
                 <>
                   <p style={{ fontWeight: 600, marginBottom: 4 }}>Scraper is ready</p>
                   <p className="text-sm text-muted">
-                    {channels.length === 0
-                      ? 'Add channels below, then click Run to fetch EPG data.'
+                    {noConfiguredChannels
+                      ? 'No scraper channels are currently configured in channels.xml. Add and enable channels before running the scraper.'
                       : `${enabledCount} channel${enabledCount !== 1 ? 's' : ''} configured. Click Run to fetch latest EPG data.`}
                   </p>
                 </>
@@ -211,7 +219,7 @@ export default function ScraperPage() {
             </div>
             <button
               className="btn btn-primary"
-              disabled={!status?.online || running || channels.length === 0}
+              disabled={!status?.online || running || noConfiguredChannels}
               onClick={runScraper}
               style={{ flexShrink: 0, minWidth: 120, justifyContent: 'center' }}
             >
@@ -221,6 +229,15 @@ export default function ScraperPage() {
               }
             </button>
           </div>
+
+
+          {status?.online && noConfiguredChannels && (
+            <div style={{ marginTop: 12, padding: '10px 12px', borderRadius: 8, background: 'color-mix(in oklab, var(--yellow) 14%, var(--surface))', border: '1px solid color-mix(in oklab, var(--yellow) 30%, var(--border2))' }}>
+              <p className="text-sm" style={{ color: 'var(--text)', margin: 0 }}>
+                ⚠ No scraper channels are selected. The sidecar can run, but it will produce no guide and <span className="mono">/guide.xml</span> may return 404 until channels are added.
+              </p>
+            </div>
+          )}
 
           {runDone && !running && (
             <div style={{ marginTop: 12, paddingTop: 12, borderTop: '1px solid var(--border2)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -382,7 +399,7 @@ export default function ScraperPage() {
               <div className="empty-state">
                 <Terminal size={32}/>
                 <p>No run yet</p>
-                <p className="text-sm text-faint">Add channels then click Run now</p>
+                <p className="text-sm text-faint">Add and enable at least one scraper channel, then click Run now</p>
               </div>
             ) : (
               <div style={{ background: 'var(--bg)', borderRadius: 8, padding: '12px 14px', fontFamily: 'monospace', fontSize: 12, lineHeight: 1.8, maxHeight: 500, overflowY: 'auto', border: '1px solid var(--border)' }}>


### PR DESCRIPTION
### Motivation
- Users saw the scraper sidecar appear to fail (404 /guide.xml or “found 0 channel(s)”) when the generated `channels.xml` was empty, which looked like a generic error and was confusing. 
- The goal is to make the API and Scraper page explicitly detect and explain the zero-channel case without changing the scraper architecture.

### Description
- Backend now counts configured `<channel>` entries in the generated `channels.xml` and exposes `configured_channel_count`, `enabled_channel_count`, and `no_channels_configured` on `/api/scraper/status` and uses this check in `run` and `guide.xml` handling (`backend/src/routes/scraper.js`).
- `/api/scraper/guide.xml` returns a friendly `404` JSON payload with `code: NO_SCRAPER_CHANNELS` when the scraper sidecar returns 404 and no channels are configured instead of surfacing a generic failure.
- `/api/scraper/run` (SSE) now early-exits with a clear SSE error if `channels.xml` contains zero channels so manual runs are blocked with a helpful message rather than producing empty output.
- Scraper UI updates (`frontend/src/pages/Scraper.jsx`) show a clear warning banner when no scraper channels are configured, disable the Run button in that state and show a toast if the user attempts to run, improve status/empty-state copy to instruct adding and enabling channels, and surface a friendlier log message when auto-fetch fails due to no scraper channels.
- Added an Unreleased note to `CHANGELOG.md` documenting the UX/API improvement.

### Testing
- Built the frontend for production with `npm --prefix frontend run build` and the build completed successfully. 
- No other automated test suites were changed or run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c629f02f8833186ee082c0311ce15)