### PR TITLE
Skip obvious VOD/series entries during M3U import and add import summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- Playlist M3U import now classifies obvious VOD/movie/series entries and skips them by default so live-channel counts are clearer and less inflated.
+- Added import summary fields (`total_entries`, `imported_live`, `skipped_vod_like`, `include_vod_like`) to the playlist import API response.
+- Scheduler refresh logs now report total parsed entries vs imported live channels and skipped VOD-like entries.
+
 ## [1.0.7] — 2026-05-19
 
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Playlist M3U import now classifies obvious VOD/movie/series entries and skips them by default so live-channel counts are clearer and less inflated.
+- Refined VOD-like classifier to prioritize URL-path signals (`/movie/`, `/series/`, `/vod/`) and conservative episode/group heuristics, reducing false positives on legitimate live channels.
 - Added import summary fields (`total_entries`, `imported_live`, `skipped_vod_like`, `include_vod_like`) to the playlist import API response.
 - Scheduler refresh logs now report total parsed entries vs imported live channels and skipped VOD-like entries.
 

--- a/backend/src/routes/playlists.js
+++ b/backend/src/routes/playlists.js
@@ -138,7 +138,8 @@ router.post('/:id/import', async (req, res) => {
     }
   }
 
-  const channels = parseM3U(m3uText);
+  const includeVodLike = req.body.include_vod_like === true;
+  const { channels, counts } = parseM3U(m3uText, { includeVodLike });
 
   const insert = db.prepare(`
     INSERT INTO channels (playlist_id, name, url, duration, tvg_id, tvg_name, tvg_logo, grp, epg_id, enabled, ord)
@@ -151,7 +152,15 @@ router.post('/:id/import', async (req, res) => {
     db.prepare("UPDATE playlists SET updated_at=datetime('now'), last_refreshed=datetime('now') WHERE id=?").run(pl.id);
   })(channels);
 
-  res.json({ imported: channels.length });
+  res.json({
+    imported: channels.length,
+    import_summary: {
+      total_entries: counts.totalEntries,
+      imported_live: counts.importedLive,
+      skipped_vod_like: counts.skippedVodLike,
+      include_vod_like: includeVodLike,
+    },
+  });
 });
 
 // POST /api/playlists/:id/refresh — manual trigger of auto-refresh

--- a/backend/src/scheduler.js
+++ b/backend/src/scheduler.js
@@ -30,7 +30,7 @@ async function refreshPlaylist(pl) {
     const r = await fetch(url, { timeout: 30000, follow: 10, compress: true });
     if (!r.ok) throw new Error('HTTP ' + r.status);
     const text = await r.text();
-    const channels = parseM3U(text);
+    const { channels, counts } = parseM3U(text);
 
     const insert = db.prepare(`
       INSERT INTO channels (playlist_id, name, url, duration, tvg_id, tvg_name, tvg_logo, grp, epg_id, enabled, ord)
@@ -43,7 +43,7 @@ async function refreshPlaylist(pl) {
       db.prepare("UPDATE playlists SET last_refreshed=datetime('now'), updated_at=datetime('now') WHERE id=?").run(pl.id);
     })();
 
-    console.log(`[scheduler] Playlist "${pl.name}" refreshed — ${channels.length} channels`);
+    console.log(`[scheduler] Playlist "${pl.name}" refreshed — ${counts.importedLive}/${counts.totalEntries} live channels imported (${counts.skippedVodLike} VOD-like entries skipped)`);
   } catch (e) {
     console.error(`[scheduler] Failed to refresh playlist "${pl.name}":`, e.message);
   }

--- a/backend/src/utils/m3u.js
+++ b/backend/src/utils/m3u.js
@@ -1,9 +1,29 @@
 /**
  * Parse an M3U/M3U8 playlist string into an array of channel objects.
  */
-function parseM3U(text) {
+function classifyEntry({ attrs, name = '', url = '' }) {
+  const group = (attrs['group-title'] || '').toLowerCase();
+  const tvgName = (attrs['tvg-name'] || '').toLowerCase();
+  const lowerName = (name || '').toLowerCase();
+  const lowerUrl = (url || '').toLowerCase();
+
+  const combined = `${group} ${tvgName} ${lowerName}`;
+  const vodKeywordRe = /\b(vod|movie|movies|film|films|serie|series|s\d+\s*e\d+|season\s*\d+|episode\s*\d+)\b/;
+  const urlVodRe = /\/(movie|series|vod)\//;
+
+  const looksLikeVod = vodKeywordRe.test(combined) || urlVodRe.test(lowerUrl);
+  return looksLikeVod ? 'vod_like' : 'live';
+}
+
+function parseM3U(text, options = {}) {
+  const { includeVodLike = false } = options;
   const lines = text.split(/\r?\n/).filter(l => l.trim());
   const channels = [];
+  const counts = {
+    totalEntries: 0,
+    importedLive: 0,
+    skippedVodLike: 0,
+  };
   let i = lines[0]?.startsWith('#EXTM3U') ? 1 : 0;
 
   while (i < lines.length) {
@@ -27,6 +47,14 @@ function parseM3U(text) {
     // Channel display name is everything after the last comma
     const name = (line.match(/,(.+)$/) || [, ''])[1].trim() || attrs['tvg-name'] || 'Unknown';
 
+    counts.totalEntries += 1;
+    const classification = classifyEntry({ attrs, name, url });
+    if (classification === 'vod_like' && !includeVodLike) {
+      counts.skippedVodLike += 1;
+      i = j + 1;
+      continue;
+    }
+
     channels.push({
       name,
       url,
@@ -38,11 +66,12 @@ function parseM3U(text) {
       epg_id:    '',
       enabled:   1,
     });
+    counts.importedLive += 1;
 
     i = j + 1;
   }
 
-  return channels;
+  return { channels, counts };
 }
 
 /**

--- a/backend/src/utils/m3u.js
+++ b/backend/src/utils/m3u.js
@@ -3,16 +3,28 @@
  */
 function classifyEntry({ attrs, name = '', url = '' }) {
   const group = (attrs['group-title'] || '').toLowerCase();
-  const tvgName = (attrs['tvg-name'] || '').toLowerCase();
-  const lowerName = (name || '').toLowerCase();
   const lowerUrl = (url || '').toLowerCase();
+  const lowerName = (name || '').toLowerCase();
+  const tvgName = (attrs['tvg-name'] || '').toLowerCase();
 
-  const combined = `${group} ${tvgName} ${lowerName}`;
-  const vodKeywordRe = /\b(vod|movie|movies|film|films|serie|series|s\d+\s*e\d+|season\s*\d+|episode\s*\d+)\b/;
+  // Heuristic notes:
+  // 1) URL path is the strongest signal for Xtream-style VOD/movie/series entries.
+  // 2) Episode patterns in names are strong signals for series episodes, even without URL hints.
+  // 3) Group-name checks are intentionally conservative and only match obviously VOD-only buckets.
+  //    We intentionally do NOT treat generic words in channel names (movie/film/series) as enough to skip,
+  //    because that can hide legitimate live channels.
   const urlVodRe = /\/(movie|series|vod)\//;
+  const episodePatternRe = /\b(s\d{1,2}\s*e\d{1,3}|\d{1,2}x\d{1,3}|season\s*\d{1,2}\s*episode\s*\d{1,3}|episode\s*\d{1,3})\b/;
+  const vodGroupRe = /^\s*(vod|movies?|series)\s*([|\-:/].*)?$/;
 
-  const looksLikeVod = vodKeywordRe.test(combined) || urlVodRe.test(lowerUrl);
-  return looksLikeVod ? 'vod_like' : 'live';
+  if (urlVodRe.test(lowerUrl)) return 'vod_like';
+
+  const combinedName = `${lowerName} ${tvgName}`.trim();
+  if (episodePatternRe.test(combinedName)) return 'vod_like';
+
+  if (vodGroupRe.test(group)) return 'vod_like';
+
+  return 'live';
 }
 
 function parseM3U(text, options = {}) {


### PR DESCRIPTION
### Motivation
- Large provider playlists contained both live channels and VOD/movie/series sections which were all previously treated as channels and inserted into the `channels` table, inflating refresh counts. 
- The Xtream-compatible path fetches an M3U and uses the same M3U parser, so Xtream-derived movie/series entries were also counted as channels.

### Description
- Added a lightweight M3U entry classifier in `backend/src/utils/m3u.js` that labels entries as `live` or `vod_like` using conservative heuristics (group/title keywords and URL path hints). 
- `parseM3U` now returns `{ channels, counts }` and by default skips `vod_like` entries; the import can be forced with the request flag `include_vod_like: true`. 
- `POST /api/playlists/:id/import` was updated to accept `include_vod_like` and to return `import_summary` with `total_entries`, `imported_live`, `skipped_vod_like`, and `include_vod_like`. 
- Scheduler refresh logs were updated to print `importedLive/totalEntries` and the number of skipped VOD-like entries, and `CHANGELOG.md` was updated under `Unreleased`. 
- Follow-up work still recommended: persist per-playlist import mode so scheduled refreshes can be configured without an API-body flag, and expand classification rules or add Xtream-specific handling if provider metadata becomes available.

### Testing
- Built the frontend with `npm run build` in `frontend/` and the build completed successfully. 
- Verified the server code compiles / runs locally (no unit tests were added or run as part of this change). 
- Confirmed updated import path and scheduler logging via local code inspection and print statements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7b7f89148331bf487235364fd90c)