### PR TITLE
Improve EPG scraper feedback for zero-programme runs (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Refined VOD-like classifier to prioritize URL-path signals (`/movie/`, `/series/`, `/vod/`) and conservative episode/group heuristics, reducing false positives on legitimate live channels.
 - Added import summary fields (`total_entries`, `imported_live`, `skipped_vod_like`, `include_vod_like`) to the playlist import API response.
 - Scheduler refresh logs now report total parsed entries vs imported live channels and skipped VOD-like entries.
+- EPG scraper run logs now surface zero-programme outcomes with a clear warning and suggestion to try another scraper source/site.
+- Scraper post-run checks now summarize generated `guide.xml` channel/programme counts so empty-programme guides are obvious.
+- Auto-fetch logs now include loaded channel counts plus programme-entry counts when importing scraper output into Stationarr.
+- EPG scraper help text now clarifies that adding one scraper channel only generates guide data for that selected channel.
 
 ## [1.0.7] — 2026-05-19
 

--- a/backend/src/routes/epg.js
+++ b/backend/src/routes/epg.js
@@ -6,8 +6,13 @@ const { saveEPGCache, deleteEPGCache } = require('../utils/xmltv-merge');
 const { readProgrammes } = require('../utils/epg-reader');
 const fetch   = require('node-fetch');
 const path    = require('path');
+const fs      = require('fs');
 
 const DATA_DIR = process.env.DATA_DIR || './data';
+function countProgrammeEntriesFromText(text) {
+  const matches = String(text || '').match(/<programme\b/g);
+  return matches ? matches.length : 0;
+}
 
 router.use(requireAuth);
 
@@ -129,7 +134,6 @@ router.post('/:id/fetch', async (req, res) => {
   if (!src) return res.status(404).json({ error: 'Not found' });
   if (!src.url) return res.status(400).json({ error: 'Source has no URL' });
 
-  const fs   = require('fs');
   const path = require('path');
   const tmpPath = path.join(DATA_DIR, 'epg_cache', `tmp_${src.id}.xml`);
 
@@ -159,7 +163,8 @@ router.post('/:id/fetch', async (req, res) => {
 
     storeEPGChannels(src.id, channels, cachePath, size);
     try { require('./guide').clearCache(); } catch {}
-    res.json({ loaded: channels.length, cache_size: size, cached: true });
+    const programmeCount = countProgrammeEntriesFromText(fs.readFileSync(cachePath, 'utf8'));
+    res.json({ loaded: channels.length, cache_size: size, cached: true, programme_count: programmeCount });
   } catch (e) {
     // Clean up tmp file on error
     try { require('fs').unlinkSync(tmpPath); } catch {}
@@ -179,7 +184,8 @@ router.post('/:id/upload', async (req, res) => {
     const { cachePath, size } = saveEPGCache(DATA_DIR, src.id, buf);
     storeEPGChannels(src.id, channels, cachePath, size);
     try { require('./guide').clearCache(); } catch {}
-    res.json({ loaded: channels.length, cache_size: size, cached: true });
+    const programmeCount = countProgrammeEntriesFromText(buf.toString('utf8'));
+    res.json({ loaded: channels.length, cache_size: size, cached: true, programme_count: programmeCount });
   } catch (e) {
     res.status(500).json({ error: 'Parse failed: ' + e.message });
   }

--- a/backend/src/routes/scraper.js
+++ b/backend/src/routes/scraper.js
@@ -17,6 +17,19 @@ function getConfiguredChannelCountFromXML() {
   return matches ? matches.length : 0;
 }
 
+async function getGuideStats(scraperUrl) {
+  try {
+    const r = await fetch(`${scraperUrl}/guide.xml`, { timeout: 30000 });
+    if (!r.ok) return null;
+    const xml = await r.text();
+    const channelCount = (xml.match(/<channel\b/g) || []).length;
+    const programmeCount = (xml.match(/<programme\b/g) || []).length;
+    return { channelCount, programmeCount };
+  } catch {
+    return null;
+  }
+}
+
 // ── Status ────────────────────────────────────────────────────────
 router.get('/status', requireAuth, async (req, res) => {
   const enabledCount = db.prepare(
@@ -237,6 +250,13 @@ router.get('/run', async (req, res) => {
   const send = (data) => {
     try { res.write(`data: ${JSON.stringify(data)}\n\n`); } catch {}
   };
+  const runLines = [];
+  const pushRunLine = (line) => {
+    const trimmed = (line || '').trim();
+    if (!trimmed) return;
+    runLines.push(trimmed);
+    send({ type: 'log', msg: trimmed });
+  };
 
   const scraperUrl = process.env.SCRAPER_URL || 'http://epg:3000';
   const configuredCount = getConfiguredChannelCountFromXML();
@@ -286,13 +306,27 @@ router.get('/run', async (req, res) => {
     const proc = spawn('docker', ['exec', '-w', '/epg', epgContainer, 'npm', 'run', 'grab', '--', '--channels=/epg/public/channels.xml']);
 
     proc.stdout.on('data', (d) => {
-      d.toString().split('\n').filter(l => l.trim()).forEach(line => send({ type: 'log', msg: line }));
+      d.toString().split('\n').forEach(pushRunLine);
     });
     proc.stderr.on('data', (d) => {
-      d.toString().split('\n').filter(l => l.trim()).forEach(line => send({ type: 'log', msg: line }));
+      d.toString().split('\n').forEach(pushRunLine);
     });
-    proc.on('close', (code) => {
+    proc.on('close', async (code) => {
       if (code === 0 || code === null) {
+        const zeroProgramLines = runLines.filter(l => /\(0 programs\)/i.test(l));
+        if (zeroProgramLines.length > 0) {
+          send({ type: 'warning', msg: 'Scraper ran, but no programmes were found for the selected channels/source.' });
+          send({ type: 'warning', msg: 'Try another scraper source/site for this channel.' });
+          zeroProgramLines.slice(0, 5).forEach(l => send({ type: 'warning', msg: `↳ ${l}` }));
+        }
+        const stats = await getGuideStats(scraperUrl);
+        if (stats) {
+          send({ type: 'log', msg: `Generated guide.xml contains ${stats.channelCount} channel(s) and ${stats.programmeCount} programme(s).` });
+          if (stats.channelCount > 0 && stats.programmeCount === 0) {
+            send({ type: 'warning', msg: 'Scraper ran, but no programmes were found for the selected channels/source.' });
+            send({ type: 'warning', msg: 'Try another scraper source/site for this channel.' });
+          }
+        }
         send({ type: 'done', msg: 'Scrape completed! Stationarr will now fetch the guide...' });
       } else {
         send({ type: 'error', msg: `Scraper exited with code ${code}` });

--- a/frontend/src/pages/Scraper.jsx
+++ b/frontend/src/pages/Scraper.jsx
@@ -118,7 +118,14 @@ export default function ScraperPage() {
       }
       setLogs(prev => [...prev, { type: 'log', msg: 'Fetching guide into Stationarr...' }]);
       const res = await epgApi.fetch(src.id);
-      setLogs(prev => [...prev, { type: 'done', msg: `✓ Done! Loaded ${res.loaded} channels into Stationarr EPG cache.` }]);
+      const programmeCount = Number.isFinite(res?.programme_count) ? res.programme_count : null;
+      setLogs(prev => [...prev, { type: 'done', msg: `✓ Done! Loaded ${res.loaded} channels into Stationarr EPG cache${programmeCount !== null ? ` (${programmeCount} programme entries).` : '.'}` }]);
+      if (programmeCount === 0) {
+        setLogs(prev => [...prev,
+          { type: 'warning', msg: 'Scraper ran, but no programmes were found for the selected channels/source.' },
+          { type: 'warning', msg: 'Try another scraper source/site for this channel.' },
+        ]);
+      }
       load();
     } catch (e) {
       const friendly = e.message?.includes('NO_SCRAPER_CHANNELS')
@@ -207,7 +214,7 @@ export default function ScraperPage() {
                   <p className="text-sm text-muted">
                     {noConfiguredChannels
                       ? 'No scraper channels are currently configured in channels.xml. Add and enable channels before running the scraper.'
-                      : `${enabledCount} channel${enabledCount !== 1 ? 's' : ''} configured. Click Run to fetch latest EPG data.`}
+                      : `${enabledCount} channel${enabledCount !== 1 ? 's' : ''} configured. Click Run to fetch latest EPG data. Note: only selected scraper channels are included in generated guide data.`}
                   </p>
                 </>
               ) : (
@@ -340,6 +347,7 @@ export default function ScraperPage() {
                 <p>2. Pick which scraper site to use (use the one for your country)</p>
                 <p>3. Once you've added all your channels, click <strong style={{ color: 'var(--text)' }}>Run now</strong> at the top</p>
                 <p>4. Stationarr fetches the EPG data and caches it automatically — no terminal needed</p>
+                <p>5. Important: adding one scraper channel only fetches guide data for that specific selected channel.</p>
               </div>
             )}
 
@@ -407,6 +415,7 @@ export default function ScraperPage() {
                   <div key={i} style={{
                     color: log.type === 'error' ? 'var(--red)'
                          : log.type === 'done'  ? 'var(--green)'
+                         : log.type === 'warning' ? 'var(--yellow)'
                          : 'var(--text)',
                   }}>
                     {log.msg}


### PR DESCRIPTION
### Motivation
- Improve user feedback when the EPG scraper completes and produces channels but no programme entries so the UI does not appear to silently succeed with an empty guide. 

### Description
- Capture streamed scraper output during runs and detect log lines matching `(0 programs)`, surfacing them as SSE `warning` entries with the message "Scraper ran, but no programmes were found for the selected channels/source." and a suggestion to try another source. 
- After a successful run call `getGuideStats` to fetch the generated `guide.xml` and count `<channel>` and `<programme>` tags, then log a summary `X channel(s) and Y programme(s)` and emit the same warning if channels > 0 and programmes = 0. 
- Expose programme counts from EPG fetch/upload endpoints by adding `programme_count` (detected with `countProgrammeEntriesFromText`) so the frontend can show channel + programme totals after auto-fetch. 
- Frontend changes display the `programme_count` in the auto-fetch success message, render warning lines in a distinct color, and clarify help text that adding one scraper channel only fetches guide data for that selected channel. 
- Updated `CHANGELOG.md` under `Unreleased` to document the new zero-programme warnings, post-run guide summary, auto-fetch programme counts, and help text clarification. 

### Testing
- Built the frontend with `npm run build` (in `frontend/`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c85c416f48331a27715febdec3900)