### PR TITLE
Resolve scraper channel site_id from iptv-org/epg definitions (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Scraper channel add flow now resolves and stores valid site-specific `site_id`/`xmltv_id` definitions from iptv-org/epg instead of guessing `site_id` from a channel id.
 - Added fallback lookup + clear error messaging when a site-specific scraper channel definition cannot be found for the selected site/channel pair.
 - Scraper channel-definition lookup now supports standard Docker Compose deployments by falling back to iptv-org/epg GitHub site files when local `/epg/sites` definitions are not mounted into the Stationarr container.
+- Scraper definition lookup now also checks nested iptv-org/epg site paths (e.g. `sites/tvguide.com/tvguide.com.channels.xml`) for both local and GitHub fallback sources.
 
 ## [1.0.8] — 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Scraper channel add flow now resolves and stores valid site-specific `site_id`/`xmltv_id` definitions from iptv-org/epg instead of guessing `site_id` from a channel id.
 - Added fallback lookup + clear error messaging when a site-specific scraper channel definition cannot be found for the selected site/channel pair.
+- Scraper channel-definition lookup now supports standard Docker Compose deployments by falling back to iptv-org/epg GitHub site files when local `/epg/sites` definitions are not mounted into the Stationarr container.
 
 ## [1.0.8] — 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Scraper channel add flow now resolves and stores valid site-specific `site_id`/`xmltv_id` definitions from iptv-org/epg instead of guessing `site_id` from a channel id.
+- Added fallback lookup + clear error messaging when a site-specific scraper channel definition cannot be found for the selected site/channel pair.
+
 ## [1.0.8] — 2026-05-19
 
 ### Changed

--- a/backend/src/routes/scraper.js
+++ b/backend/src/routes/scraper.js
@@ -10,6 +10,9 @@ const DATA_DIR      = process.env.DATA_DIR || './data';
 const SCRAPER_URL   = process.env.SCRAPER_URL || 'http://epg:3000';
 const CHANNELS_PATH = process.env.SCRAPER_CHANNELS_PATH || path.join(DATA_DIR, 'scraper', 'channels.xml');
 const EPG_SITES_DIR = process.env.EPG_SITES_DIR || '/epg/sites';
+const EPG_SITES_REMOTE_BASE = process.env.EPG_SITES_REMOTE_BASE || 'https://raw.githubusercontent.com/iptv-org/epg/master/sites';
+const SITE_DEF_CACHE_TTL_MS = Number(process.env.EPG_SITES_CACHE_TTL_MS || (6 * 60 * 60 * 1000));
+const siteDefCache = new Map();
 
 function getConfiguredChannelCountFromXML() {
   if (!fs.existsSync(CHANNELS_PATH)) return 0;
@@ -69,13 +72,13 @@ router.get('/channels', requireAuth, (req, res) => {
 });
 
 // ── Add channel ───────────────────────────────────────────────────
-router.post('/channels', requireAuth, (req, res) => {
+router.post('/channels', requireAuth, async (req, res) => {
   const { xmltv_id, site, site_id, name, lang, channel_id } = req.body;
   if (!site || !name) {
     return res.status(400).json({ error: 'site and name required' });
   }
 
-  const resolved = resolveScraperChannelDefinition({ site, xmltv_id, site_id, name, channel_id });
+  const resolved = await resolveScraperChannelDefinition({ site, xmltv_id, site_id, name, channel_id });
   if (!resolved.ok) {
     return res.status(422).json({
       error: resolved.error,
@@ -216,13 +219,16 @@ function parseCSV(text) {
   }).filter(ch => ch.id && ch.name);
 }
 
-function resolveScraperChannelDefinition({ site, xmltv_id, site_id, name, channel_id }) {
+async function resolveScraperChannelDefinition({ site, xmltv_id, site_id, name, channel_id }) {
   // Preserve site-specific definition when client already provides both fields
   if (xmltv_id && site_id) return { ok: true, xmltv_id, site_id };
 
-  const defs = loadSiteChannelDefinitions(site);
+  const defs = await loadSiteChannelDefinitions(site);
   if (!defs.length) {
-    return { ok: false, error: `No scraper channel definitions found for site "${site}".` };
+    return {
+      ok: false,
+      error: `No scraper channel definitions found for site "${site}" (checked ${EPG_SITES_DIR} and ${EPG_SITES_REMOTE_BASE}).`,
+    };
   }
 
   const norm = (v) => String(v || '').trim().toLowerCase();
@@ -238,13 +244,19 @@ function resolveScraperChannelDefinition({ site, xmltv_id, site_id, name, channe
   return { ok: false, error: `No valid site_id mapping found for "${name}" on ${site}.` };
 }
 
-function loadSiteChannelDefinitions(site) {
-  const xml = readSiteChannelsXML(site);
-  if (!xml) return [];
-  return parseSiteChannelsXML(xml);
+async function loadSiteChannelDefinitions(site) {
+  const cacheKey = String(site || '').toLowerCase();
+  const now = Date.now();
+  const cached = siteDefCache.get(cacheKey);
+  if (cached && (now - cached.ts) < SITE_DEF_CACHE_TTL_MS) return cached.defs;
+
+  const xml = await readSiteChannelsXML(site);
+  const defs = xml ? parseSiteChannelsXML(xml) : [];
+  siteDefCache.set(cacheKey, { ts: now, defs });
+  return defs;
 }
 
-function readSiteChannelsXML(site) {
+async function readSiteChannelsXML(site) {
   const safe = String(site || '').replace(/[^a-zA-Z0-9._-]/g, '');
   const candidates = [
     path.join(EPG_SITES_DIR, safe + '.channels.xml'),
@@ -253,6 +265,17 @@ function readSiteChannelsXML(site) {
   ];
   for (const file of candidates) {
     if (fs.existsSync(file)) return fs.readFileSync(file, 'utf8');
+  }
+
+  const remoteCandidates = [
+    `${EPG_SITES_REMOTE_BASE}/${encodeURIComponent(safe)}.channels.xml`,
+    `${EPG_SITES_REMOTE_BASE}/${encodeURIComponent(safe)}.xml`,
+  ];
+  for (const url of remoteCandidates) {
+    try {
+      const r = await fetch(url, { timeout: 10000 });
+      if (r.ok) return await r.text();
+    } catch {}
   }
   return null;
 }

--- a/backend/src/routes/scraper.js
+++ b/backend/src/routes/scraper.js
@@ -9,6 +9,7 @@ const { exec, spawn } = require('child_process');
 const DATA_DIR      = process.env.DATA_DIR || './data';
 const SCRAPER_URL   = process.env.SCRAPER_URL || 'http://epg:3000';
 const CHANNELS_PATH = process.env.SCRAPER_CHANNELS_PATH || path.join(DATA_DIR, 'scraper', 'channels.xml');
+const EPG_SITES_DIR = process.env.EPG_SITES_DIR || '/epg/sites';
 
 function getConfiguredChannelCountFromXML() {
   if (!fs.existsSync(CHANNELS_PATH)) return 0;
@@ -69,18 +70,26 @@ router.get('/channels', requireAuth, (req, res) => {
 
 // ── Add channel ───────────────────────────────────────────────────
 router.post('/channels', requireAuth, (req, res) => {
-  const { xmltv_id, site, site_id, name, lang } = req.body;
-  if (!xmltv_id || !site || !site_id || !name) {
-    return res.status(400).json({ error: 'xmltv_id, site, site_id, name required' });
+  const { xmltv_id, site, site_id, name, lang, channel_id } = req.body;
+  if (!site || !name) {
+    return res.status(400).json({ error: 'site and name required' });
+  }
+
+  const resolved = resolveScraperChannelDefinition({ site, xmltv_id, site_id, name, channel_id });
+  if (!resolved.ok) {
+    return res.status(422).json({
+      error: resolved.error,
+      hint: 'Pick a different site for this channel, or update scraper definitions so this site/channel pair exists in iptv-org/epg.',
+    });
   }
 
   // Check not duplicate
-  const exists = db.prepare('SELECT id FROM scraper_channels WHERE user_id = ? AND xmltv_id = ? AND site = ?').get(req.user.id, xmltv_id, site);
+  const exists = db.prepare('SELECT id FROM scraper_channels WHERE user_id = ? AND xmltv_id = ? AND site = ?').get(req.user.id, resolved.xmltv_id, site);
   if (exists) return res.status(409).json({ error: 'Channel already added for this site' });
 
   const result = db.prepare(
     'INSERT INTO scraper_channels (user_id, xmltv_id, site, site_id, name, lang) VALUES (?,?,?,?,?,?)'
-  ).run(req.user.id, xmltv_id, site, site_id, name, lang || 'en');
+  ).run(req.user.id, resolved.xmltv_id, site, resolved.site_id, name, lang || 'en');
 
   const ch = db.prepare('SELECT * FROM scraper_channels WHERE id = ?').get(result.lastInsertRowid);
   writeChannelsXML(req.user.id);
@@ -205,6 +214,72 @@ function parseCSV(text) {
     header.forEach((h, i) => obj[h] = vals[i] || '');
     return obj;
   }).filter(ch => ch.id && ch.name);
+}
+
+function resolveScraperChannelDefinition({ site, xmltv_id, site_id, name, channel_id }) {
+  // Preserve site-specific definition when client already provides both fields
+  if (xmltv_id && site_id) return { ok: true, xmltv_id, site_id };
+
+  const defs = loadSiteChannelDefinitions(site);
+  if (!defs.length) {
+    return { ok: false, error: `No scraper channel definitions found for site "${site}".` };
+  }
+
+  const norm = (v) => String(v || '').trim().toLowerCase();
+  const byId = defs.find(d => norm(d.xmltv_id) === norm(xmltv_id));
+  if (byId) return { ok: true, xmltv_id: byId.xmltv_id, site_id: byId.site_id };
+
+  const byChannelId = defs.find(d => norm(d.channel_id) === norm(channel_id));
+  if (byChannelId) return { ok: true, xmltv_id: byChannelId.xmltv_id, site_id: byChannelId.site_id };
+
+  const byName = defs.find(d => norm(d.name) === norm(name));
+  if (byName) return { ok: true, xmltv_id: byName.xmltv_id, site_id: byName.site_id };
+
+  return { ok: false, error: `No valid site_id mapping found for "${name}" on ${site}.` };
+}
+
+function loadSiteChannelDefinitions(site) {
+  const xml = readSiteChannelsXML(site);
+  if (!xml) return [];
+  return parseSiteChannelsXML(xml);
+}
+
+function readSiteChannelsXML(site) {
+  const safe = String(site || '').replace(/[^a-zA-Z0-9._-]/g, '');
+  const candidates = [
+    path.join(EPG_SITES_DIR, safe + '.channels.xml'),
+    path.join(EPG_SITES_DIR, safe, 'channels.xml'),
+    path.join(EPG_SITES_DIR, safe + '.xml'),
+  ];
+  for (const file of candidates) {
+    if (fs.existsSync(file)) return fs.readFileSync(file, 'utf8');
+  }
+  return null;
+}
+
+function parseSiteChannelsXML(xml) {
+  const out = [];
+  const regex = /<channel\b([^>]*)>([^<]*)<\/channel>/g;
+  let match;
+  while ((match = regex.exec(xml)) !== null) {
+    const attrs = parseXmlAttrs(match[1]);
+    if (!attrs.site_id || !attrs.xmltv_id) continue;
+    out.push({
+      site_id: attrs.site_id,
+      xmltv_id: attrs.xmltv_id,
+      channel_id: attrs.channel_id || '',
+      name: (match[2] || '').trim(),
+    });
+  }
+  return out;
+}
+
+function parseXmlAttrs(attrStr) {
+  const attrs = {};
+  const regex = /(\w+)="([^"]*)"/g;
+  let m;
+  while ((m = regex.exec(attrStr)) !== null) attrs[m[1]] = m[2];
+  return attrs;
 }
 
 // Curated list of well-supported scraper sites

--- a/backend/src/routes/scraper.js
+++ b/backend/src/routes/scraper.js
@@ -259,6 +259,7 @@ async function loadSiteChannelDefinitions(site) {
 async function readSiteChannelsXML(site) {
   const safe = String(site || '').replace(/[^a-zA-Z0-9._-]/g, '');
   const candidates = [
+    path.join(EPG_SITES_DIR, safe, safe + '.channels.xml'),
     path.join(EPG_SITES_DIR, safe + '.channels.xml'),
     path.join(EPG_SITES_DIR, safe, 'channels.xml'),
     path.join(EPG_SITES_DIR, safe + '.xml'),
@@ -268,6 +269,7 @@ async function readSiteChannelsXML(site) {
   }
 
   const remoteCandidates = [
+    `${EPG_SITES_REMOTE_BASE}/${encodeURIComponent(safe)}/${encodeURIComponent(safe)}.channels.xml`,
     `${EPG_SITES_REMOTE_BASE}/${encodeURIComponent(safe)}.channels.xml`,
     `${EPG_SITES_REMOTE_BASE}/${encodeURIComponent(safe)}.xml`,
   ];

--- a/frontend/src/pages/Scraper.jsx
+++ b/frontend/src/pages/Scraper.jsx
@@ -157,7 +157,7 @@ export default function ScraperPage() {
       await api.addChannel({
         xmltv_id: ch.id,
         site:     site.site,
-        site_id:  ch.id.split('.')[0],
+        channel_id: ch.id,
         name:     ch.name,
         lang:     ch.languages?.split(';')[0]?.trim() || 'en',
       });


### PR DESCRIPTION
### Motivation
- Stationarr was guessing scraper `site_id` (e.g. using `xmltv_id.split('.')[0]`) which produced invalid site-specific entries for iptv-org/epg-backed scrapers and broke some scraper sources.\
- The goal is to store the exact site-specific channel definition from iptv-org/epg when adding scraper channels so the sidecar can generate valid `channels.xml` entries.\

### Description
- Reworked the scraper add flow to resolve and persist a valid site-specific `xmltv_id`/`site_id` pair before inserting into `scraper_channels`, and return a clear `422` error with a hint when no mapping is found.\
- Added helpers and a configurable `EPG_SITES_DIR` (default `/epg/sites`) to load and parse iptv-org/epg site channel XML files and match definitions by `xmltv_id`, `channel_id`, or channel name.\
- Preserved existing behaviour when the client already provides both `xmltv_id` and `site_id`, to avoid breaking previously saved scraper channels.\
- Updated the frontend add-channel payload to send `channel_id` (full iptv-org channel id) instead of guessing `site_id`, letting the backend resolve the correct site-specific mapping.\
- Updated `CHANGELOG.md` under Unreleased and referenced issue #13.\

### Testing
- Built the frontend with `npm --prefix frontend run build`, which completed successfully.\
- Attempted to validate presence of site-specific definitions (e.g. `ESPN.us@SD` / `9200006937`) under `/epg/sites`, but the directory was not available in this environment so live mapping validation could not complete.\
- No automated unit tests for this specific flow were present or run; change is covered by the backend insert path and frontend build verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca650d6fc8331b24ab9f2ad0491d3)