### PR TITLE
Show EPG programme counts and improve scraper UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 - Scraper channel-definition lookup now supports standard Docker Compose deployments by falling back to iptv-org/epg GitHub site files when local `/epg/sites` definitions are not mounted into the Stationarr container.
 - Scraper definition lookup now also checks nested iptv-org/epg site paths (e.g. `sites/tvguide.com/tvguide.com.channels.xml`) for both local and GitHub fallback sources.
 
+### Improved
+- EPG source cache status now shows programme counts alongside channel counts, cache size, and cache age in the EPG Sources modal.
+- EPG fetch/upload/manual refresh flows now return and display `programme_count`, and scheduler refreshes now count/store/log programme totals.
+- Added a new “How the EPG scraper works” help section on the EPG Scraper page with clearer sidecar vs Stationarr scheduler behaviour.
+- Added troubleshooting hints for common scraper outcomes: `0 channels` and `0 programmes`.
+
 ## [1.0.8] — 2026-05-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Improved
 - EPG source cache status now shows programme counts alongside channel counts, cache size, and cache age in the EPG Sources modal.
 - EPG fetch/upload/manual refresh flows now return and display `programme_count`, and scheduler refreshes now count/store/log programme totals.
+- Programme counting now handles both plain XMLTV and `.xml.gz` sources safely when calculating `programme_count`.
 - Added a new “How the EPG scraper works” help section on the EPG Scraper page with clearer sidecar vs Stationarr scheduler behaviour.
 - Added troubleshooting hints for common scraper outcomes: `0 channels` and `0 programmes`.
 

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -119,6 +119,7 @@ if (!chCols.includes('timeshift')) db.exec("ALTER TABLE channels ADD COLUMN time
 // EPG source priority column
 const epgCols3 = db.prepare("PRAGMA table_info(epg_sources)").all().map(c => c.name);
 if (!epgCols3.includes('priority')) db.exec("ALTER TABLE epg_sources ADD COLUMN priority INTEGER DEFAULT 0");
+if (!epgCols3.includes('programme_count')) db.exec("ALTER TABLE epg_sources ADD COLUMN programme_count INTEGER DEFAULT 0");
 
 // EPG scraper config table
 db.exec(`

--- a/backend/src/routes/epg.js
+++ b/backend/src/routes/epg.js
@@ -120,7 +120,8 @@ router.get('/:id/fetch-stream', async (req, res) => {
     // Clear guide cache so next guide load is fresh
     try { require('./guide').clearCache(); } catch {}
 
-    send({ phase: 'done', loaded: channels.length, cache_size: size });
+    const programmeCount = countProgrammeEntriesFromText(buf.toString('utf8'));
+    send({ phase: 'done', loaded: channels.length, cache_size: size, programme_count: programmeCount });
     res.end();
   } catch (e) {
     send({ phase: 'error', message: e.message });
@@ -161,9 +162,9 @@ router.post('/:id/fetch', async (req, res) => {
     const cachePath = path.join(DATA_DIR, 'epg_cache', `source_${src.id}.xml`);
     fs.renameSync(tmpPath, cachePath);
 
-    storeEPGChannels(src.id, channels, cachePath, size);
-    try { require('./guide').clearCache(); } catch {}
     const programmeCount = countProgrammeEntriesFromText(fs.readFileSync(cachePath, 'utf8'));
+    storeEPGChannels(src.id, channels, cachePath, size, programmeCount);
+    try { require('./guide').clearCache(); } catch {}
     res.json({ loaded: channels.length, cache_size: size, cached: true, programme_count: programmeCount });
   } catch (e) {
     // Clean up tmp file on error
@@ -182,9 +183,9 @@ router.post('/:id/upload', async (req, res) => {
     const buf      = Buffer.from(content, 'utf8');
     const channels = await parseXMLTVBuffer(buf);
     const { cachePath, size } = saveEPGCache(DATA_DIR, src.id, buf);
-    storeEPGChannels(src.id, channels, cachePath, size);
-    try { require('./guide').clearCache(); } catch {}
     const programmeCount = countProgrammeEntriesFromText(buf.toString('utf8'));
+    storeEPGChannels(src.id, channels, cachePath, size, programmeCount);
+    try { require('./guide').clearCache(); } catch {}
     res.json({ loaded: channels.length, cache_size: size, cached: true, programme_count: programmeCount });
   } catch (e) {
     res.status(500).json({ error: 'Parse failed: ' + e.message });
@@ -196,7 +197,7 @@ router.delete('/:id/cache', (req, res) => {
   const src = db.prepare('SELECT * FROM epg_sources WHERE id=? AND user_id=?').get(req.params.id, req.user.id);
   if (!src) return res.status(404).json({ error: 'Not found' });
   deleteEPGCache(src.cache_path);
-  db.prepare("UPDATE epg_sources SET cache_path=NULL, cache_size=0, cache_updated=NULL WHERE id=?").run(src.id);
+  db.prepare("UPDATE epg_sources SET cache_path=NULL, cache_size=0, cache_updated=NULL, programme_count=0 WHERE id=?").run(src.id);
   res.json({ ok: true });
 });
 
@@ -327,7 +328,7 @@ function fuzzy(s) {
     .replace(/[^a-z0-9]/g, '');            // strip all non-alphanumeric
 }
 
-function storeEPGChannels(sourceId, channels, cachePath, cacheSize) {
+function storeEPGChannels(sourceId, channels, cachePath, cacheSize, programmeCount = 0) {
   const insert = db.prepare('INSERT INTO epg_channels (source_id, tvg_id, name, icon) VALUES (?,?,?,?)');
   // Filter out channels with no ID or name — these would violate NOT NULL constraints
   const valid = channels.filter(c => (c.tvg_id || c.id) && (c.name || '').trim());
@@ -336,10 +337,10 @@ function storeEPGChannels(sourceId, channels, cachePath, cacheSize) {
     valid.forEach(c => insert.run(sourceId, c.tvg_id || c.id, c.name, c.icon || ''));
     db.prepare(`
       UPDATE epg_sources
-      SET last_fetched=datetime('now'), channel_count=?, cache_path=?, cache_size=?,
+      SET last_fetched=datetime('now'), channel_count=?, programme_count=?, cache_path=?, cache_size=?,
           cache_updated=datetime('now'), last_refreshed=datetime('now')
       WHERE id=?
-    `).run(valid.length, cachePath || null, cacheSize || 0, sourceId);
+    `).run(valid.length, Number(programmeCount) || 0, cachePath || null, cacheSize || 0, sourceId);
   })();
 }
 

--- a/backend/src/routes/epg.js
+++ b/backend/src/routes/epg.js
@@ -4,15 +4,12 @@ const requireAuth = require('../middleware/auth');
 const { parseXMLTV, parseXMLTVBuffer } = require('../utils/xmltv');
 const { saveEPGCache, deleteEPGCache } = require('../utils/xmltv-merge');
 const { readProgrammes } = require('../utils/epg-reader');
+const { countProgrammeEntriesFromBuffer } = require('../utils/xmltv-programme-count');
 const fetch   = require('node-fetch');
 const path    = require('path');
 const fs      = require('fs');
 
 const DATA_DIR = process.env.DATA_DIR || './data';
-function countProgrammeEntriesFromText(text) {
-  const matches = String(text || '').match(/<programme\b/g);
-  return matches ? matches.length : 0;
-}
 
 router.use(requireAuth);
 
@@ -120,7 +117,7 @@ router.get('/:id/fetch-stream', async (req, res) => {
     // Clear guide cache so next guide load is fresh
     try { require('./guide').clearCache(); } catch {}
 
-    const programmeCount = countProgrammeEntriesFromText(buf.toString('utf8'));
+    const programmeCount = countProgrammeEntriesFromBuffer(buf);
     send({ phase: 'done', loaded: channels.length, cache_size: size, programme_count: programmeCount });
     res.end();
   } catch (e) {
@@ -162,7 +159,7 @@ router.post('/:id/fetch', async (req, res) => {
     const cachePath = path.join(DATA_DIR, 'epg_cache', `source_${src.id}.xml`);
     fs.renameSync(tmpPath, cachePath);
 
-    const programmeCount = countProgrammeEntriesFromText(fs.readFileSync(cachePath, 'utf8'));
+    const programmeCount = countProgrammeEntriesFromBuffer(fs.readFileSync(cachePath));
     storeEPGChannels(src.id, channels, cachePath, size, programmeCount);
     try { require('./guide').clearCache(); } catch {}
     res.json({ loaded: channels.length, cache_size: size, cached: true, programme_count: programmeCount });
@@ -183,7 +180,7 @@ router.post('/:id/upload', async (req, res) => {
     const buf      = Buffer.from(content, 'utf8');
     const channels = await parseXMLTVBuffer(buf);
     const { cachePath, size } = saveEPGCache(DATA_DIR, src.id, buf);
-    const programmeCount = countProgrammeEntriesFromText(buf.toString('utf8'));
+    const programmeCount = countProgrammeEntriesFromBuffer(buf);
     storeEPGChannels(src.id, channels, cachePath, size, programmeCount);
     try { require('./guide').clearCache(); } catch {}
     res.json({ loaded: channels.length, cache_size: size, cached: true, programme_count: programmeCount });

--- a/backend/src/scheduler.js
+++ b/backend/src/scheduler.js
@@ -12,6 +12,10 @@ const { saveEPGCache } = require('./utils/xmltv-merge');
 
 const DATA_DIR    = process.env.DATA_DIR || './data';
 const CHECK_EVERY = 15 * 60 * 1000; // 15 minutes
+function countProgrammeEntriesFromText(text) {
+  const matches = String(text || '').match(/<programme\b/g);
+  return matches ? matches.length : 0;
+}
 
 function buildM3UUrl(pl) {
   if (pl.source_type === 'xtream' && pl.source_server && pl.source_username && pl.source_password) {
@@ -59,6 +63,7 @@ async function refreshEPGSource(src) {
     const buf = await r.buffer();
     const channels = await parseXMLTVBuffer(buf);
     const { cachePath, size } = saveEPGCache(DATA_DIR, src.id, buf);
+    const programmeCount = countProgrammeEntriesFromText(buf.toString('utf8'));
 
     const insert = db.prepare('INSERT INTO epg_channels (source_id, tvg_id, name, icon) VALUES (?,?,?,?)');
     db.transaction(() => {
@@ -66,13 +71,13 @@ async function refreshEPGSource(src) {
       channels.forEach(c => insert.run(src.id, c.id, c.name, c.icon || ''));
       db.prepare(`
         UPDATE epg_sources
-        SET last_fetched=datetime('now'), channel_count=?, cache_path=?, cache_size=?,
+        SET last_fetched=datetime('now'), channel_count=?, programme_count=?, cache_path=?, cache_size=?,
             cache_updated=datetime('now'), last_refreshed=datetime('now')
         WHERE id=?
-      `).run(channels.length, cachePath, size, src.id);
+      `).run(channels.length, programmeCount, cachePath, size, src.id);
     })();
 
-    console.log(`[scheduler] EPG source "${src.name}" refreshed — ${channels.length} channels, ${(size/1024/1024).toFixed(1)} MB`);
+    console.log(`[scheduler] EPG source "${src.name}" refreshed — ${channels.length} channels, ${programmeCount} programmes, ${(size/1024/1024).toFixed(1)} MB`);
   } catch (e) {
     console.error(`[scheduler] Failed to refresh EPG source "${src.name}":`, e.message);
   }

--- a/backend/src/scheduler.js
+++ b/backend/src/scheduler.js
@@ -9,14 +9,10 @@ const fetch = require('node-fetch');
 const { parseM3U }  = require('./utils/m3u');
 const { parseXMLTVBuffer } = require('./utils/xmltv');
 const { saveEPGCache } = require('./utils/xmltv-merge');
+const { countProgrammeEntriesFromBuffer } = require('./utils/xmltv-programme-count');
 
 const DATA_DIR    = process.env.DATA_DIR || './data';
 const CHECK_EVERY = 15 * 60 * 1000; // 15 minutes
-function countProgrammeEntriesFromText(text) {
-  const matches = String(text || '').match(/<programme\b/g);
-  return matches ? matches.length : 0;
-}
-
 function buildM3UUrl(pl) {
   if (pl.source_type === 'xtream' && pl.source_server && pl.source_username && pl.source_password) {
     const base = pl.source_server.replace(/\/$/, '');
@@ -63,7 +59,7 @@ async function refreshEPGSource(src) {
     const buf = await r.buffer();
     const channels = await parseXMLTVBuffer(buf);
     const { cachePath, size } = saveEPGCache(DATA_DIR, src.id, buf);
-    const programmeCount = countProgrammeEntriesFromText(buf.toString('utf8'));
+    const programmeCount = countProgrammeEntriesFromBuffer(buf);
 
     const insert = db.prepare('INSERT INTO epg_channels (source_id, tvg_id, name, icon) VALUES (?,?,?,?)');
     db.transaction(() => {

--- a/backend/src/utils/xmltv-programme-count.js
+++ b/backend/src/utils/xmltv-programme-count.js
@@ -1,0 +1,25 @@
+const zlib = require('zlib');
+
+function looksLikeGzip(buf) {
+  return Buffer.isBuffer(buf) && buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b;
+}
+
+function countProgrammeEntriesFromXmlText(text) {
+  const matches = String(text || '').match(/<programme\b/g);
+  return matches ? matches.length : 0;
+}
+
+function countProgrammeEntriesFromBuffer(buf) {
+  try {
+    if (!Buffer.isBuffer(buf)) return 0;
+    const xmlBuffer = looksLikeGzip(buf) ? zlib.gunzipSync(buf) : buf;
+    return countProgrammeEntriesFromXmlText(xmlBuffer.toString('utf8'));
+  } catch {
+    return 0;
+  }
+}
+
+module.exports = {
+  countProgrammeEntriesFromBuffer,
+  countProgrammeEntriesFromXmlText,
+};

--- a/frontend/src/components/EPGPanel.jsx
+++ b/frontend/src/components/EPGPanel.jsx
@@ -78,10 +78,10 @@ export default function EPGPanel({ sources, onClose, onChange }) {
     setProgress(p => ({ ...p, [id]: { phase: 'downloading', percent: null, message: 'Downloading & parsing… this may take a minute for large files' } }));
     try {
       const res = await api.fetch(id);
-      toast(`Loaded ${res.loaded} channels · ${formatSize(res.cache_size)} cached`, 'success');
+      toast(`Loaded ${res.loaded} channels · ${res.programme_count ?? 0} programmes · ${formatSize(res.cache_size)} cached`, 'success');
       // Update ordered sources in place so UI refreshes without waiting for parent
       setOrderedSources(prev => prev.map(s => s.id === id
-        ? { ...s, channel_count: res.loaded, cache_size: res.cache_size, cache_updated: new Date().toISOString() }
+        ? { ...s, channel_count: res.loaded, programme_count: res.programme_count ?? s.programme_count ?? 0, cache_size: res.cache_size, cache_updated: new Date().toISOString() }
         : s
       ));
       onChange();
@@ -97,7 +97,7 @@ export default function EPGPanel({ sources, onClose, onChange }) {
 
   const manualRefresh = async (id) => {
     setBusyFor(id, 'refresh');
-    try { const res = await api.refresh(id); toast(`Refreshed — ${res.channel_count} channels`, 'success'); onChange(); }
+    try { const res = await api.refresh(id); toast(`Refreshed — ${res.channel_count} channels · ${res.programme_count ?? 0} programmes`, 'success'); onChange(); }
     catch (err) { toast(err.message, 'error'); }
     finally { setBusyFor(id, false); }
   };
@@ -108,7 +108,11 @@ export default function EPGPanel({ sources, onClose, onChange }) {
       setBusyFor(id, 'upload');
       try {
         const res = await api.upload(id, { content: e.target.result });
-        toast(`Loaded ${res.loaded} channels · ${formatSize(res.cache_size)} cached`, 'success');
+        toast(`Loaded ${res.loaded} channels · ${res.programme_count ?? 0} programmes · ${formatSize(res.cache_size)} cached`, 'success');
+        setOrderedSources(prev => prev.map(s => s.id === id
+          ? { ...s, channel_count: res.loaded, programme_count: res.programme_count ?? s.programme_count ?? 0, cache_size: res.cache_size, cache_updated: new Date().toISOString() }
+          : s
+        ));
         onChange();
       } catch (err) { toast(err.message, 'error'); }
       finally { setBusyFor(id, false); }
@@ -209,7 +213,7 @@ export default function EPGPanel({ sources, onClose, onChange }) {
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
                       <HardDrive size={11} color="var(--green)" />
                       <span className="text-xs text-muted">
-                        {src.channel_count} channels · {formatSize(src.cache_size)} · cached {timeAgo(src.cache_updated)}
+                        {formatCacheSummary(src)}
                       </span>
                       <button className="btn btn-ghost btn-sm" style={{ padding: '2px 6px', fontSize: 11, color: 'var(--faint)' }} onClick={() => clearCache(src.id)}>clear</button>
                     </div>
@@ -316,4 +320,10 @@ function timeAgo(iso) {
   const hrs = Math.floor(mins / 60);
   if (hrs < 24)  return `${hrs}h ago`;
   return `${Math.floor(hrs / 24)}d ago`;
+}
+
+function formatCacheSummary(src) {
+  const channels = Number(src.channel_count || 0);
+  const programmes = Number(src.programme_count || 0);
+  return `${channels} channel${channels === 1 ? '' : 's'} · ${programmes} programme${programmes === 1 ? '' : 's'} · ${formatSize(src.cache_size)} · cached ${timeAgo(src.cache_updated)}`;
 }

--- a/frontend/src/pages/Scraper.jsx
+++ b/frontend/src/pages/Scraper.jsx
@@ -254,6 +254,28 @@ export default function ScraperPage() {
           )}
         </div>
 
+        <div className="card" style={{ background: 'var(--surface2)' }}>
+          <p style={{ fontWeight: 600, marginBottom: 8 }}>How the EPG scraper works</p>
+          <ol className="text-sm text-muted" style={{ margin: 0, paddingLeft: 18, lineHeight: 1.8 }}>
+            <li>Add scraper channels from a supported source/site.</li>
+            <li>Run the scraper now, or let the sidecar run on its own cron schedule.</li>
+            <li>Stationarr fetches and caches <span className="mono">guide.xml</span> into EPG Sources.</li>
+            <li>Match playlist channels to EPG IDs.</li>
+            <li>Open the Guide.</li>
+          </ol>
+          <div style={{ marginTop: 10, fontSize: 12, color: 'var(--muted)', lineHeight: 1.7 }}>
+            <p>• EPG source auto-refresh is handled by Stationarr’s scheduler.</p>
+            <p>• The sidecar scraper cron is separate from Stationarr scheduling.</p>
+            <p>• Immediate <strong style={{ color: 'var(--text)' }}>Run now</strong> from Stationarr requires Docker socket access.</p>
+            <p>• EPG sources with auto-refresh enabled are checked by Stationarr’s scheduler.</p>
+          </div>
+          <div style={{ marginTop: 8, fontSize: 12, color: 'var(--muted)', lineHeight: 1.7 }}>
+            <p>Troubleshooting:</p>
+            <p>• <strong style={{ color: 'var(--text)' }}>0 channels</strong> means no scraper channels are selected.</p>
+            <p>• <strong style={{ color: 'var(--text)' }}>0 programmes</strong> means the source/site returned no programme data, or the scraper channel definition may be invalid.</p>
+          </div>
+        </div>
+
         {/* Tabs */}
         <div style={{ display: 'flex', borderBottom: '1px solid var(--border2)' }}>
           {[

--- a/frontend/src/pages/Scraper.jsx
+++ b/frontend/src/pages/Scraper.jsx
@@ -249,7 +249,7 @@ export default function ScraperPage() {
           {runDone && !running && (
             <div style={{ marginTop: 12, paddingTop: 12, borderTop: '1px solid var(--border2)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
               <p className="text-sm text-green">✓ EPG data fetched and cached in Stationarr</p>
-              <button className="btn btn-sm" onClick={() => nav('/settings')}>Go to EPG Sources →</button>
+              <button className="btn btn-sm" onClick={() => nav('/settings', { state: { openEpgSources: true } })}>Go to EPG Sources →</button>
             </div>
           )}
         </div>
@@ -454,7 +454,7 @@ export default function ScraperPage() {
             )}
             {runDone && (
               <div style={{ display: 'flex', gap: 8 }}>
-                <button className="btn btn-primary" onClick={() => nav('/settings')}>Go to EPG Sources →</button>
+                <button className="btn btn-primary" onClick={() => nav('/settings', { state: { openEpgSources: true } })}>Go to EPG Sources →</button>
                 <button className="btn" onClick={runScraper}><Play size={12}/> Run again</button>
               </div>
             )}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,16 +1,18 @@
 import HeaderButtons from '../components/HeaderButtons.jsx';
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { ArrowLeft, Tv, Rss, Download, Upload } from 'lucide-react';
 import { applyTheme, getTheme } from '../components/ThemeToggle.jsx';
-import { auth as api, backup as backupApi } from '../api.js';
+import { auth as api, backup as backupApi, epg as epgApi } from '../api.js';
 import { useAuth, useToast } from '../context.jsx';
 import { useTZ, TIMEZONE_GROUPS } from '../timezone.jsx';
+import EPGPanel from '../components/EPGPanel.jsx';
 
 export default function Settings() {
   const { user, logout } = useAuth();
   const toast = useToast();
   const nav   = useNavigate();
+  const location = useLocation();
   const { tz, setTimezone, fmtTime } = useTZ();
 
   const [theme, setTheme] = useState(getTheme);
@@ -20,6 +22,8 @@ export default function Settings() {
   const [form, setForm]     = useState({ current: '', next: '', confirm: '' });
   const [saving,    setSaving]    = useState(false);
   const [restoring, setRestoring] = useState(false);
+  const [showEPG, setShowEPG] = useState(false);
+  const [epgSources, setEpgSources] = useState([]);
 
   const [version, setVersion] = useState(null);
   useEffect(() => {
@@ -28,6 +32,19 @@ export default function Settings() {
       .then(d => { if (d.version) setVersion(d.version); })
       .catch(() => {});
   }, []);
+
+  const loadEpgSources = async () => {
+    try { setEpgSources(await epgApi.list()); }
+    catch (err) { toast(err.message, 'error'); }
+  };
+
+  useEffect(() => {
+    if (location.state?.openEpgSources) {
+      setShowEPG(true);
+      loadEpgSources();
+      nav(location.pathname, { replace: true, state: {} });
+    }
+  }, [location.state, location.pathname]);
 
   const set = (k) => (e) => setForm(f => ({ ...f, [k]: e.target.value }));
 
@@ -144,7 +161,7 @@ export default function Settings() {
         {/* EPG Scraper */}
         <div>
           <h2 style={{ fontSize: 15, fontWeight: 600, marginBottom: 12 }}>EPG scraper</h2>
-          <div className="card" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div className="card" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
             <div>
               <p style={{ fontWeight: 500, marginBottom: 4 }}>iptv-org/epg integration</p>
               <p className="text-sm text-muted">Manage which channels the scraper fetches, view status, and configure the sidecar container.</p>
@@ -153,6 +170,12 @@ export default function Settings() {
               <Rss size={13}/> Open scraper
             </button>
           </div>
+          <button
+            className="btn btn-sm"
+            onClick={() => { setShowEPG(true); loadEpgSources(); }}
+          >
+            Open EPG Sources
+          </button>
         </div>
 
         {/* Backup & Restore */}
@@ -250,6 +273,14 @@ export default function Settings() {
           </div>
         </div>
       </main>
+
+      {showEPG && (
+        <EPGPanel
+          sources={epgSources}
+          onClose={() => setShowEPG(false)}
+          onChange={loadEpgSources}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Make EPG source cache status more informative by surfacing programme counts alongside channel count, cache size and age. 
- Clarify how the EPG scraper / sidecar and Stationarr scheduler interact so users understand automatic vs manual refresh behaviour. 
- Avoid risky DB migrations while adding the ability to store programme totals where simple column additions suffice.

### Description
- Add a safe runtime DB migration and `programme_count` column to `epg_sources` so programme totals can be persisted (`backend/src/db.js`).
- Count `<programme>` entries during fetch/upload/scheduler refresh flows, return `programme_count` in API responses, store/reset it on the source record, and include programme totals in SSE/refresh logs (`backend/src/routes/epg.js`, `backend/src/scheduler.js`).
- Update the EPG sources UI to display programme counts in the cached-status summary and include programme totals in fetch/upload/refresh toasts and immediate UI updates (`frontend/src/components/EPGPanel.jsx`).
- Add a clear “How the EPG scraper works” help card with steps, scheduler vs sidecar clarifications, Docker socket note for immediate runs, and troubleshooting hints for `0 channels` / `0 programmes` (`frontend/src/pages/Scraper.jsx`).
- Update `CHANGELOG.md` Unreleased section to document these UX and API improvements.

### Testing
- Built the frontend with `npm run build` (from `frontend/`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb3df8fd483319c2ba6709f1636fc)