### PR TITLE
Fix Docker fresh-volume EACCES and document correct scraper volume mapping (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Docker startup now proactively creates `/app/data` and `/app/data/scraper`, repairs ownership for UID/GID `1000`, and then starts Node as the non-root `node` user to prevent EACCES on fresh named volumes.
+- Added startup warnings when `SCRAPER_CHANNELS_PATH` points outside `/app/data`, including a specific warning against using `/epg/public` in the Stationarr container.
+
+### Documentation
+- Updated `docker run` and `docker-compose` examples to use the correct shared volume mapping: Stationarr writes `/app/data/scraper/channels.xml` and the EPG sidecar mounts that same volume at `/epg/public`.
+
 ## [1.0.9] — 2026-05-19
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM node:22-alpine3.23
 WORKDIR /app
 
 # Upgrade Alpine packages + add docker-cli for optional EPG scraper feature
-RUN apk upgrade --no-cache && apk add --no-cache docker-cli
+RUN apk upgrade --no-cache && apk add --no-cache docker-cli su-exec
 ENV DOCKER_API_VERSION=1.41
 
 # Copy pre-compiled node_modules — no build tools needed in final image
@@ -26,14 +26,15 @@ COPY --from=backend-builder /app/node_modules ./node_modules
 COPY backend/src ./src
 COPY backend/package.json ./package.json
 COPY --from=frontend-builder /build/public ./public
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
-# Create data dir owned by the node user (non-root)
-RUN mkdir -p /app/data && chown -R node:node /app/data
+# Create runtime data dirs (final ownership is enforced at container start)
+RUN mkdir -p /app/data /app/data/scraper && chown -R node:node /app/data
 
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV DATA_DIR=/app/data
 
 EXPOSE 3000
-USER node
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "src/index.js"]

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ docker run -d \
   --name stationarr \
   -p 3000:3000 \
   -e JWT_SECRET=change-me-to-something-random \
+  -e SCRAPER_CHANNELS_PATH=/app/data/scraper/channels.xml \
   -v stationarr_data:/app/data \
+  -v stationarr_scraper_shared:/app/data/scraper \
   rroy676/stationarr:latest
 ```
 
@@ -127,6 +129,17 @@ docker compose up -d
 ```
 
 Open `http://localhost:3000` and register your account. The first account is automatically admin.
+
+If you also run the optional iptv-org/epg sidecar, mount the same shared scraper volume at `/epg/public` in that container:
+
+```bash
+docker run -d \
+  --name stationarr-epg \
+  -v stationarr_scraper_shared:/epg/public \
+  ghcr.io/iptv-org/epg:master
+```
+
+> Keep Stationarr `SCRAPER_CHANNELS_PATH` under `/app/data` (recommended: `/app/data/scraper/channels.xml`). Do **not** set it to `/epg/public/channels.xml` because `/epg/public` is the sidecar container path.
 
 ### With iptv-org/epg scraper (optional)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
       - "3000:3000"
     volumes:
       - stationarr_data:/app/data
-      - scraper_shared:/app/data/scraper
+      # Shared with epg sidecar; Stationarr writes channels.xml here
+      - stationarr_scraper_shared:/app/data/scraper
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - PORT=3000
@@ -17,6 +18,7 @@ services:
       - BASE_URL=${BASE_URL:-http://localhost:3000}
       - REGISTRATION_OPEN=${REGISTRATION_OPEN:-true}
       - SCRAPER_URL=http://stationarr-epg:3000
+      # Must stay under /app/data for Stationarr; do not point to /epg/public
       - SCRAPER_CHANNELS_PATH=/app/data/scraper/channels.xml
       - DOCKER_API_VERSION=1.41
     networks:
@@ -27,7 +29,8 @@ services:
     container_name: stationarr-epg
     restart: unless-stopped
     volumes:
-      - scraper_shared:/epg/public
+      # Same shared volume mounted in sidecar path expected by iptv-org/epg
+      - stationarr_scraper_shared:/epg/public
     environment:
       - CRON_SCHEDULE=0 */6 * * *
       - DAYS=3
@@ -38,7 +41,7 @@ services:
 
 volumes:
   stationarr_data:
-  scraper_shared:
+  stationarr_scraper_shared:
 
 networks:
   stationarr_net:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -eu
+
+DATA_DIR="${DATA_DIR:-/app/data}"
+SCRAPER_DIR="${DATA_DIR}/scraper"
+APP_USER="node"
+APP_UID="1000"
+APP_GID="1000"
+SCRAPER_CHANNELS_PATH="${SCRAPER_CHANNELS_PATH:-${SCRAPER_DIR}/channels.xml}"
+
+mkdir -p "$DATA_DIR" "$SCRAPER_DIR"
+
+if [ "$(id -u)" = "0" ]; then
+  chown -R "${APP_UID}:${APP_GID}" "$DATA_DIR"
+fi
+
+case "$SCRAPER_CHANNELS_PATH" in
+  "$DATA_DIR"/*) ;;
+  *)
+    echo "[WARN] SCRAPER_CHANNELS_PATH is outside DATA_DIR: $SCRAPER_CHANNELS_PATH" >&2
+    if [ "$SCRAPER_CHANNELS_PATH" = "/epg/public/channels.xml" ] || [ "${SCRAPER_CHANNELS_PATH#"/epg/public"}" != "$SCRAPER_CHANNELS_PATH" ]; then
+      echo "[WARN] Do not point Stationarr to /epg/public. Keep SCRAPER_CHANNELS_PATH under $DATA_DIR (recommended: $SCRAPER_DIR/channels.xml)." >&2
+    fi
+    ;;
+esac
+
+if [ "$(id -u)" = "0" ]; then
+  exec su-exec "$APP_USER" "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
### Motivation
- Fresh Docker named volumes can be root-owned causing `EACCES` when Stationarr (runs as non-root `node` UID 1000) writes `/app/data/scraper/channels.xml`, so startup must ensure proper dirs and ownership without requiring host `chown` calls.
- Users were sometimes configuring `SCRAPER_CHANNELS_PATH` to the sidecar path `/epg/public`, which is incorrect and can cause confusion or permission issues between containers.

### Description
- Added `docker-entrypoint.sh` that creates `/app/data` and `/app/data/scraper`, repairs ownership to UID/GID `1000:1000` when starting as root, warns when `SCRAPER_CHANNELS_PATH` is outside `/app/data` (with a specific warning against `/epg/public`), and drops privileges to the `node` user before launching the app.
- Updated `Dockerfile` to install `su-exec`, copy the new entrypoint, create runtime data dirs, and use `ENTRYPOINT` so ownership repair runs at container start.
- Updated `docker-compose.yml` to clarify volume mapping and renamed the scraper shared volume to `stationarr_scraper_shared` with comments showing Stationarr mounts `/app/data/scraper` and the EPG sidecar mounts the same volume at `/epg/public`.
- Updated `README.md` with a corrected `docker run` example that mounts `-v stationarr_data:/app/data` and `-v stationarr_scraper_shared:/app/data/scraper` and added an example for starting the EPG sidecar mounting the same shared volume at `/epg/public` plus the explicit warning not to set `SCRAPER_CHANNELS_PATH` to `/epg/public/channels.xml`.
- Added `Unreleased` notes to `CHANGELOG.md` documenting the fix and the documentation changes and referenced issue #18 in the PR metadata.

### Testing
- Attempted `docker build` and run validation but it failed because `docker` is not available in this execution environment, so image startup could not be end-to-end validated (failure due to `/bin/bash: docker: command not found`).
- Performed static verification of modified files (`Dockerfile`, `docker-entrypoint.sh`, `docker-compose.yml`, `README.md`, `CHANGELOG.md`) and confirmed the entrypoint is copied and `ENTRYPOINT`/`CMD` flow is correct.
- Committed the changes and verified repository state with `git status` and file listings, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cc18071b08331b7971d0ad09f03d9)