### PR TITLE
Handle stale JWT tokens during scraper channel add (fix #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Fixed
+- Fixed stale JWT handling for scraper channel adds: auth now verifies the token user still exists before setting `req.user`, returns `401` with `STALE_TOKEN` for missing users, and scraper channel insert now catches SQLite FK constraint errors to return clean JSON instead of crashing the backend.
+- Frontend auth handling now preserves and shows backend session-expired messages on redirect to login, avoiding generic browser fetch/network errors when tokens are stale.
+
 - Docker startup now proactively creates `/app/data` and `/app/data/scraper`, repairs ownership for UID/GID `1000`, and then starts Node as the non-root `node` user to prevent EACCES on fresh named volumes.
 - Added startup warnings when `SCRAPER_CHANNELS_PATH` points outside `/app/data`, including a specific warning against using `/epg/public` in the Stationarr container.
 - Fixed scraper first-run fallback when Docker CLI/socket access is unavailable: Stationarr now checks `SCRAPER_URL/guide.xml` before auto-fetching and no longer emits success/done states when the file is missing (404).

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,12 +1,24 @@
 const jwt = require('jsonwebtoken');
+const db = require('../db');
 
 module.exports = function requireAuth(req, res, next) {
   const header = req.headers.authorization;
   if (!header || !header.startsWith('Bearer ')) {
     return res.status(401).json({ error: 'Missing token' });
   }
+
   try {
-    req.user = jwt.verify(header.slice(7), process.env.JWT_SECRET);
+    const decoded = jwt.verify(header.slice(7), process.env.JWT_SECRET);
+    const user = db.prepare('SELECT id, username, email, is_admin, created_at FROM users WHERE id = ?').get(decoded.id);
+
+    if (!user) {
+      return res.status(401).json({
+        error: 'User no longer exists. Please log in again.',
+        code: 'STALE_TOKEN',
+      });
+    }
+
+    req.user = user;
     next();
   } catch {
     res.status(401).json({ error: 'Invalid or expired token' });

--- a/backend/src/routes/scraper.js
+++ b/backend/src/routes/scraper.js
@@ -90,13 +90,29 @@ router.post('/channels', requireAuth, async (req, res) => {
   const exists = db.prepare('SELECT id FROM scraper_channels WHERE user_id = ? AND xmltv_id = ? AND site = ?').get(req.user.id, resolved.xmltv_id, site);
   if (exists) return res.status(409).json({ error: 'Channel already added for this site' });
 
-  const result = db.prepare(
-    'INSERT INTO scraper_channels (user_id, xmltv_id, site, site_id, name, lang) VALUES (?,?,?,?,?,?)'
-  ).run(req.user.id, resolved.xmltv_id, site, resolved.site_id, name, lang || 'en');
+  try {
+    const result = db.prepare(
+      'INSERT INTO scraper_channels (user_id, xmltv_id, site, site_id, name, lang) VALUES (?,?,?,?,?,?)'
+    ).run(req.user.id, resolved.xmltv_id, site, resolved.site_id, name, lang || 'en');
 
-  const ch = db.prepare('SELECT * FROM scraper_channels WHERE id = ?').get(result.lastInsertRowid);
-  writeChannelsXML(req.user.id);
-  res.status(201).json(ch);
+    const ch = db.prepare('SELECT * FROM scraper_channels WHERE id = ?').get(result.lastInsertRowid);
+    writeChannelsXML(req.user.id);
+    res.status(201).json(ch);
+  } catch (e) {
+    if (e && e.code === 'SQLITE_CONSTRAINT_FOREIGNKEY') {
+      return res.status(401).json({
+        error: 'Your session is no longer valid. Please log in again.',
+        code: 'STALE_TOKEN',
+      });
+    }
+    if (e && e.code && e.code.startsWith('SQLITE_CONSTRAINT')) {
+      return res.status(409).json({
+        error: 'Could not add scraper channel due to a database constraint.',
+        code: e.code,
+      });
+    }
+    throw e;
+  }
 });
 
 // ── Remove channel ────────────────────────────────────────────────

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -15,9 +15,11 @@ async function request(method, path, body, raw = false) {
   });
 
   if (res.status === 401) {
+    const data = await res.json().catch(() => ({}));
     localStorage.removeItem('token');
+    sessionStorage.setItem('auth_error', data.error || 'Your session is no longer valid. Please log in again.');
     window.location.href = '/login';
-    return;
+    throw new Error(data.error || 'Unauthorized');
   }
 
   if (raw) return res;

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link }      from 'react-router-dom';
 import { Tv }        from 'lucide-react';
 import { useAuth }   from '../context.jsx';
@@ -11,6 +11,14 @@ export default function Login() {
   const [loading, setLoading] = useState(false);
 
   const set = (k) => (e) => setForm(f => ({ ...f, [k]: e.target.value }));
+
+  useEffect(() => {
+    const authError = sessionStorage.getItem('auth_error');
+    if (authError) {
+      toast(authError, 'error');
+      sessionStorage.removeItem('auth_error');
+    }
+  }, [toast]);
 
   const submit = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
### Motivation
- A valid JWT that references a user ID missing from a recreated/reset SQLite DB could cause `INSERT` into `scraper_channels` to fail with a foreign-key error and crash the backend.
- The backend must never crash from a stale token and should return a clean auth error so the frontend can prompt the user to log in again.

### Description
- Harden `backend/src/middleware/auth.js` so `requireAuth` verifies the decoded JWT user exists in `users` before setting `req.user`, and returns `401` JSON with `code: "STALE_TOKEN"` and a relogin message when the user is missing.
- Add route-level safety in `backend/src/routes/scraper.js` around `POST /scraper/channels` to catch SQLite constraint errors and return JSON instead of crashing, mapping `SQLITE_CONSTRAINT_FOREIGNKEY` to a stale-token-style `401` response and other constraint failures to `409` with a clear message.
- Update `frontend/src/api.js` to preserve the backend `401` error message in `sessionStorage`, clear the token, redirect to `/login`, and throw a controlled error so the UI sees a useful message rather than a generic fetch/network error.
- Update `frontend/src/pages/Login.jsx` to read the preserved auth error from `sessionStorage` and display it in a toast on the login page, and update `CHANGELOG.md` under Unreleased to document the fix. 

### Testing
- Backend syntax checks passed for the modified backend files (`auth.js` and `scraper.js`).
- Frontend production build succeeded (`cd frontend && npm run build`) validating the API and login page changes in a real build.
- `node --check` for `.jsx` files is unsupported in this environment, so the `.jsx` changes were validated via the successful Vite production build instead.

Fixes #22.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cfb9bd0ec833196e5253f69a9b599)