### PR TITLE
Improve playlist import/refresh messaging for HTTP 451 (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Improved playlist import and refresh HTTP 451 handling: Stationarr now keeps the technical `HTTP 451` status context in logs while showing a clearer user-facing/provider-facing message that the remote playlist source refused the request due to likely access restrictions/policy constraints.
 - Fixed stale JWT handling for scraper channel adds: auth now verifies the token user still exists before setting `req.user`, returns `401` with `STALE_TOKEN` for missing users, and scraper channel insert now catches SQLite FK constraint errors to return clean JSON instead of crashing the backend.
 - Frontend auth handling now preserves and shows backend session-expired messages on redirect to login, avoiding generic browser fetch/network errors when tokens are stale.
 

--- a/backend/src/routes/playlists.js
+++ b/backend/src/routes/playlists.js
@@ -3,6 +3,7 @@ const db     = require('../db');
 const requireAuth = require('../middleware/auth');
 const { nanoid }  = require('nanoid');
 const { parseM3U } = require('../utils/m3u');
+const { buildHttpStatusError, getPlaylistFetchErrorMessage } = require('../utils/http-errors');
 const fetch   = require('node-fetch');
 
 router.use(requireAuth);
@@ -125,7 +126,7 @@ router.post('/:id/import', async (req, res) => {
 
     try {
       const r = await fetch(url, { timeout: 30000, follow: 10, compress: true });
-      if (!r.ok) throw new Error('HTTP ' + r.status);
+      if (!r.ok) throw buildHttpStatusError(r.status);
       m3uText = await r.text();
 
       // Save credentials to playlist for future auto-refresh
@@ -134,7 +135,7 @@ router.post('/:id/import', async (req, res) => {
         WHERE id=?
       `).run(url, req.body.source_type || 'url', req.body.source_server || null, req.body.source_username || null, req.body.source_password || null, pl.id);
     } catch (e) {
-      return res.status(502).json({ error: 'Could not fetch URL: ' + e.message });
+      return res.status(502).json({ error: getPlaylistFetchErrorMessage(e, 'Could not fetch URL:') });
     }
   }
 

--- a/backend/src/scheduler.js
+++ b/backend/src/scheduler.js
@@ -10,6 +10,7 @@ const { parseM3U }  = require('./utils/m3u');
 const { parseXMLTVBuffer } = require('./utils/xmltv');
 const { saveEPGCache } = require('./utils/xmltv-merge');
 const { countProgrammeEntriesFromBuffer } = require('./utils/xmltv-programme-count');
+const { buildHttpStatusError, getPlaylistFetchErrorMessage } = require('./utils/http-errors');
 
 const DATA_DIR    = process.env.DATA_DIR || './data';
 const CHECK_EVERY = 15 * 60 * 1000; // 15 minutes
@@ -28,7 +29,7 @@ async function refreshPlaylist(pl) {
   console.log(`[scheduler] Refreshing playlist "${pl.name}" (id=${pl.id})`);
   try {
     const r = await fetch(url, { timeout: 30000, follow: 10, compress: true });
-    if (!r.ok) throw new Error('HTTP ' + r.status);
+    if (!r.ok) throw buildHttpStatusError(r.status);
     const text = await r.text();
     const { channels, counts } = parseM3U(text);
 
@@ -45,7 +46,10 @@ async function refreshPlaylist(pl) {
 
     console.log(`[scheduler] Playlist "${pl.name}" refreshed — ${counts.importedLive}/${counts.totalEntries} live channels imported (${counts.skippedVodLike} VOD-like entries skipped)`);
   } catch (e) {
-    console.error(`[scheduler] Failed to refresh playlist "${pl.name}":`, e.message);
+    console.error(`[scheduler] Failed to refresh playlist "${pl.name}":`, getPlaylistFetchErrorMessage(e, 'Playlist fetch failed:'));
+    if (e && e.message) {
+      console.error(`[scheduler] Technical fetch error for playlist "${pl.name}":`, e.message);
+    }
   }
 }
 

--- a/backend/src/utils/http-errors.js
+++ b/backend/src/utils/http-errors.js
@@ -1,0 +1,22 @@
+const HTTP_451_MESSAGE = 'The playlist provider refused the request with HTTP 451. This may be caused by region/provider restrictions, authentication, user-agent requirements, rate limits, or access policy.';
+
+function buildHttpStatusError(status) {
+  const err = new Error('HTTP ' + status);
+  err.httpStatus = status;
+  err.userMessage = status === 451 ? HTTP_451_MESSAGE : null;
+  return err;
+}
+
+function getPlaylistFetchErrorMessage(err, prefix) {
+  const basePrefix = prefix || 'Could not fetch URL:';
+  if (err && err.httpStatus === 451) {
+    return `${basePrefix} ${HTTP_451_MESSAGE}`;
+  }
+  return `${basePrefix} ${(err && err.message) || 'Unknown error'}`;
+}
+
+module.exports = {
+  HTTP_451_MESSAGE,
+  buildHttpStatusError,
+  getPlaylistFetchErrorMessage,
+};


### PR DESCRIPTION
### Motivation
- The generic `HTTP 451` error returned during playlist imports or scheduled refreshes was unclear to users about the cause or next steps. 
- The system should preserve technical status codes for logs while presenting a clearer, actionable user-facing message for `HTTP 451`. 
- The change must affect both manual playlist imports and the scheduler refresh flow without attempting to bypass provider restrictions. 

### Description
- Added a shared helper `backend/src/utils/http-errors.js` exposing `buildHttpStatusError` and `getPlaylistFetchErrorMessage` and the clearer `HTTP 451` guidance message. 
- Updated `backend/src/routes/playlists.js` to throw `buildHttpStatusError(r.status)` for non-OK fetches and to return user-facing messages via `getPlaylistFetchErrorMessage` on import failures. 
- Updated `backend/src/scheduler.js` to use the same `buildHttpStatusError` for playlist fetch failures and to log a clearer scheduler-facing message while still emitting technical error text for troubleshooting. 
- Updated `CHANGELOG.md` under `Unreleased` and added a PR description referencing and closing issue `#24`. 

### Testing
- Ran a Node simulation using `buildHttpStatusError` and `getPlaylistFetchErrorMessage` which verified that `451` maps to the clearer guidance string while preserving the `HTTP 451` technical context; the script output matched expectations. 
- Verified that a non-451 status (e.g. `404`) still yields the normal `HTTP <status>` message via the same helper. 
- No other automated tests were modified and existing non-451 error flows remain unchanged by these edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0e4e7cb88331a6a9d9b8234fc18f)