### PR TITLE
Add v1.0.9 EPG scraper troubleshooting guidance (fixes #25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Docker entrypoint now relaxes permissions on a mounted `/var/run/docker.sock` before dropping privileges so the non-root `node` user can access Docker CLI for scraper "Run now".
 
 ### Documentation
+- Added EPG scraper troubleshooting guidance for v1.0.9 mapping changes, including re-add instructions for pre-v1.0.9 channels, first-run socket/cron behavior, `guide.xml` vs programme-count caveat, and site-specific mapping examples.
 - Updated `docker run` and `docker-compose` examples to use the correct shared volume mapping: Stationarr writes `/app/data/scraper/channels.xml` and the EPG sidecar mounts that same volume at `/epg/public`.
 - Documented first-run scraper behaviour for Docker Compose and Docker Run when Docker socket access is not mounted.
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,19 @@ docker compose up -d
 >
 > **First run behaviour (important):** If Docker socket access is not mounted, Stationarr cannot trigger the sidecar immediately. On fresh installs, `guide.xml` may not exist yet and will return `404` until the sidecar cron job runs (default every 6 hours) or you run the sidecar manually (`docker exec ... npm run grab -- --channels=/epg/public/channels.xml --output=/epg/public/guide.xml`).
 
+
+### EPG scraper troubleshooting (v1.0.9+)
+
+If your scraper setup worked before but guide entries are now missing, check the following:
+
+- **Re-add older scraper channels:** scraper channels created **before v1.0.9 (2026-05-19)** may contain legacy/invalid mappings. Remove and re-add those channels from **Settings → EPG Scraper** so Stationarr saves valid site-specific mappings.
+- **Use site-specific mapping values:** each scraper entry needs a valid `xmltv_id` + site mapping pair from the selected site definition (for example `xmltv_id="ESPN.us@SD"` and `site_id="9200006937"`).
+- **First run depends on Docker socket access:**
+  - With `/var/run/docker.sock` mounted in Stationarr, **Run now** can trigger the sidecar immediately.
+  - Without Docker socket access, Stationarr cannot start the sidecar run directly. Wait for the sidecar cron job or run it manually with `docker exec`.
+- **`guide.xml` existing is not enough:** the file can exist but still contain zero `<programme>` entries. Always verify both channel count and programme count.
+- **Cached source still needs channel matching:** even if `iptv-org/epg (scraper)` is cached in EPG Sources, guide data will not appear in the Guide until playlist channels are matched to EPG IDs in Channel Editor.
+
 ### First-run notes by deployment type
 
 - **Docker Compose (`docker compose up -d`)**

--- a/frontend/src/pages/Scraper.jsx
+++ b/frontend/src/pages/Scraper.jsx
@@ -286,8 +286,12 @@ export default function ScraperPage() {
           </div>
           <div style={{ marginTop: 8, fontSize: 12, color: 'var(--muted)', lineHeight: 1.7 }}>
             <p>Troubleshooting:</p>
+            <p>• <strong style={{ color: 'var(--text)' }}>v1.0.9 mapping update:</strong> channels added before v1.0.9 may use legacy mappings. Remove and re-add them so valid site-specific mappings are saved.</p>
+            <p>• Example valid mapping pair: <span className="mono">xmltv_id="ESPN.us@SD"</span> + <span className="mono">site_id="9200006937"</span>.</p>
             <p>• <strong style={{ color: 'var(--text)' }}>0 channels</strong> means no scraper channels are selected.</p>
-            <p>• <strong style={{ color: 'var(--text)' }}>0 programmes</strong> means the source/site returned no programme data, or the scraper channel definition may be invalid.</p>
+            <p>• <strong style={{ color: 'var(--text)' }}>guide.xml exists</strong> does not guarantee programme entries exist; it may still contain <span className="mono">0 programme</span> rows.</p>
+            <p>• <strong style={{ color: 'var(--text)' }}>Cached source but empty Guide</strong> usually means playlist channels are not yet matched to EPG IDs.</p>
+            <p>• <strong style={{ color: 'var(--text)' }}>Run now</strong> can start the sidecar immediately only when Stationarr has Docker socket access; otherwise wait for sidecar cron or run the sidecar manually.</p>
           </div>
         </div>
 


### PR DESCRIPTION
### Motivation
- Provide clear, actionable troubleshooting for EPG scraper users after the v1.0.9 mapping changes so previously-working setups can be migrated and understood. 
- Explain first-run behaviour differences when Stationarr can or cannot access the Docker socket so users know when `Run now` will trigger the sidecar. 
- Clarify common confusion points: `guide.xml` presence vs programme counts and cached EPG sources requiring playlist-to-EPG channel matching. 

### Description
- Added a new `### EPG scraper troubleshooting (v1.0.9+)` section to `README.md` that explains re-adding pre-v1.0.9 scraper channels, Docker socket vs cron/manual runs, the `guide.xml` vs programme-count caveat, cached-source matching, and includes an example mapping (`xmltv_id="ESPN.us@SD"`, `site_id="9200006937"`).
- Updated the in-app help text on `frontend/src/pages/Scraper.jsx` to surface the same troubleshooting guidance and examples in the EPG Scraper UI without altering existing Run/Go to EPG Sources flows or the update notification behaviour. 
- Updated `CHANGELOG.md` under **Unreleased → Documentation** to reference the new troubleshooting guidance and the v1.0.9 mapping note. 
- rebuilt the frontend bundle to include the UI text changes. 
- This PR references issue `#25` in the title/body. 

### Testing
- Built the frontend with `npm --prefix frontend run build`, which completed successfully (Vite build succeeded). 
- No automated backend/unit tests were modified or required for these documentation/UI text changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d12488b248331b40ca83e41842ffd)