### PR TITLE
Add Settings → Updates page with release notes and safe update instructions (keep popup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+- Added a new Settings → Updates section that keeps the existing update popup and shows current version, latest GitHub release, release date, release notes, release link, update status, and safe Docker Compose / Docker Run update instructions.
+- Update popup now links directly to Settings → Updates for in-app release details and guidance.
+
 ### Fixed
 - Improved playlist import and refresh HTTP 451 handling: Stationarr now keeps the technical `HTTP 451` status context in logs while showing a clearer user-facing/provider-facing message that the remote playlist source refused the request due to likely access restrictions/policy constraints.
 - Fixed stale JWT handling for scraper channel adds: auth now verifies the token user still exists before setting `req.user`, returns `401` with `STALE_TOKEN` for missing users, and scraper channel insert now catches SQLite FK constraint errors to return clean JSON instead of crashing the backend.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,11 +27,10 @@ function UpdateBanner() {
       <span style={{ flex: 1 }}>
         🎉 <strong>Stationarr v{latest}</strong> is available!{' '}
         <a
-          href={`https://github.com/rroy676/Stationarr/releases/tag/v${latest}`}
-          target="_blank" rel="noreferrer"
+          href="/settings?section=updates"
           style={{ color: '#fff', textDecoration: 'underline' }}
         >
-          View release
+          Open Updates
         </a>
       </span>
       <button

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -26,12 +26,33 @@ export default function Settings() {
   const [epgSources, setEpgSources] = useState([]);
 
   const [version, setVersion] = useState(null);
+  const [release, setRelease] = useState(null);
   useEffect(() => {
     fetch('/api/health')
       .then(r => r.json())
       .then(d => { if (d.version) setVersion(d.version); })
       .catch(() => {});
+
+    fetch('https://api.github.com/repos/rroy676/Stationarr/releases/latest')
+      .then(r => r.json())
+      .then(d => setRelease(d))
+      .catch(() => {});
   }, []);
+
+  useEffect(() => {
+    if (location.search.includes('section=updates')) {
+      document.getElementById('updates-section')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [location.search]);
+
+  const latestVersion = release?.tag_name?.replace(/^v/, '') || null;
+  const published = release?.published_at ? new Date(release.published_at) : null;
+  const hasUpdate = !!(version && latestVersion && latestVersion !== version);
+  const updateStatus = !version || !latestVersion
+    ? 'Checking for updates…'
+    : hasUpdate
+      ? `Update available (v${latestVersion})`
+      : 'Up to date';
 
   const loadEpgSources = async () => {
     try { setEpgSources(await epgApi.list()); }
@@ -223,6 +244,62 @@ export default function Settings() {
                 </span>
               </label>
             </div>
+          </div>
+        </div>
+
+        {/* Updates */}
+        <div id="updates-section">
+          <h2 style={{ fontSize: 15, fontWeight: 600, marginBottom: 12 }}>Updates</h2>
+          <div className="card" style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <Row label="Current version" value={version ? `v${version}` : '—'} />
+            <Row label="Latest release" value={latestVersion ? `v${latestVersion}` : '—'} />
+            <Row label="Release date" value={published ? published.toLocaleString() : '—'} />
+            <Row label="Status" value={updateStatus} />
+
+            <div style={{ marginTop: 8 }}>
+              <p style={{ fontWeight: 600, marginBottom: 6, fontSize: 13 }}>Release notes</p>
+              <div
+                style={{
+                  background: 'var(--surface2)',
+                  border: '1px solid var(--border2)',
+                  borderRadius: 8,
+                  padding: 12,
+                  whiteSpace: 'pre-wrap',
+                  fontSize: 12,
+                  maxHeight: 240,
+                  overflow: 'auto',
+                }}
+              >
+                {release?.body || 'No release notes available.'}
+              </div>
+              <a
+                href={release?.html_url || 'https://github.com/rroy676/Stationarr/releases/latest'}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: 'var(--accent)', display: 'inline-block', marginTop: 8 }}
+              >
+                View latest GitHub release
+              </a>
+            </div>
+
+            <div style={{ marginTop: 10, borderTop: '1px solid var(--border2)', paddingTop: 12 }}>
+              <p style={{ fontWeight: 600, marginBottom: 6, fontSize: 13 }}>Docker Compose update</p>
+              <pre className="mono" style={{ fontSize: 12, background: 'var(--surface2)', padding: 10, borderRadius: 8, overflow: 'auto' }}>{`cd /path/to/stationarr
+docker compose pull
+docker compose up -d`}</pre>
+            </div>
+
+            <div style={{ marginTop: 10 }}>
+              <p style={{ fontWeight: 600, marginBottom: 6, fontSize: 13 }}>Docker Run update</p>
+              <pre className="mono" style={{ fontSize: 12, background: 'var(--surface2)', padding: 10, borderRadius: 8, overflow: 'auto' }}>{`docker pull rroy676/stationarr:latest
+docker stop stationarr
+docker rm stationarr
+# rerun the original docker run command with same volumes/env`}</pre>
+            </div>
+
+            <p className="text-xs text-muted" style={{ marginTop: 2 }}>
+              Full in-app self-update is not enabled by default because it would require Docker socket access and could restart the app.
+            </p>
           </div>
         </div>
 


### PR DESCRIPTION
### Motivation
- Provide an in-app Updates area so users can view current and latest release details, release notes, and safe manual update guidance while preserving the existing update popup behavior as requested in issue #27.
- Avoid implementing auto-update/self-update that would require Docker socket access or restart the app, and give clear Docker Compose / Docker Run instructions instead.

### Description
- Updated the update notification banner to link into the new in-app updates section at `/settings?section=updates` instead of directly opening the GitHub release by changing `frontend/src/App.jsx`.
- Added release fetching and a new `Updates` section in `frontend/src/pages/Settings.jsx` that shows the current installed version, latest GitHub release version, release date, update status, release notes body, and a link to the GitHub release.
- Added boxed instructions for manual updates using `Docker Compose` and `Docker Run`, and a note that full in-app self-update is not enabled by default because it would require Docker socket access and could restart the app; the Settings page also scrolls into view when `?section=updates` is present.
- Updated `CHANGELOG.md` under **Unreleased** to document the new Updates manager and the popup linkage to Settings.

### Testing
- Ran a production frontend build with `npm --prefix frontend run build`, which completed successfully (Vite build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d1a456bc88331b84eb333e3b4227b)