### PR TITLE
feat(guide): server-side paginated guide loading with filtering and UI controls

### DIFF
--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -93,6 +93,21 @@ db.exec(`
   );
   CREATE INDEX IF NOT EXISTS idx_app_logs_ts ON app_logs(ts DESC);
 
+  CREATE TABLE IF NOT EXISTS guide_programmes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id INTEGER NOT NULL REFERENCES epg_sources(id) ON DELETE CASCADE,
+    epg_id TEXT NOT NULL,
+    start TEXT NOT NULL,
+    stop TEXT NOT NULL,
+    title TEXT NOT NULL DEFAULT '',
+    subtitle TEXT NOT NULL DEFAULT '',
+    desc TEXT NOT NULL DEFAULT '',
+    category TEXT NOT NULL DEFAULT ''
+  );
+  CREATE INDEX IF NOT EXISTS idx_gp_source_epg ON guide_programmes(source_id, epg_id);
+  CREATE INDEX IF NOT EXISTS idx_gp_epg_time ON guide_programmes(epg_id, start, stop);
+  CREATE INDEX IF NOT EXISTS idx_gp_source_time ON guide_programmes(source_id, start, stop);
+
 `);
 
 // Runtime migrations — safely add columns to existing DBs
@@ -157,3 +172,7 @@ const chCols2 = db.prepare("PRAGMA table_info(channels)").all().map(c => c.name)
 if (!chCols2.includes('backup_epg_id')) {
   db.exec("ALTER TABLE channels ADD COLUMN backup_epg_id TEXT NOT NULL DEFAULT ''");
 }
+
+if (!epgCols3.includes('guide_index_status')) db.exec("ALTER TABLE epg_sources ADD COLUMN guide_index_status TEXT DEFAULT 'idle'");
+if (!epgCols3.includes('guide_index_updated')) db.exec("ALTER TABLE epg_sources ADD COLUMN guide_index_updated TEXT");
+if (!epgCols3.includes('guide_index_error')) db.exec("ALTER TABLE epg_sources ADD COLUMN guide_index_error TEXT");

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -47,4 +47,6 @@ app.listen(PORT, () => {
   logger.info('system', 'Stationarr startup', { port: PORT, version });
   // Start background auto-refresh scheduler
   require('./scheduler').start();
+  // Queue existing stale guide indexes for cached EPG sources
+  require('./utils/guide-indexer').queueStaleGuideIndexes();
 });

--- a/backend/src/routes/epg.js
+++ b/backend/src/routes/epg.js
@@ -9,6 +9,7 @@ const fetch   = require('node-fetch');
 const path    = require('path');
 const fs      = require('fs');
 const logger  = require('../logger');
+const { queueGuideIndex } = require('../utils/guide-indexer');
 
 const DATA_DIR = process.env.DATA_DIR || './data';
 
@@ -115,6 +116,7 @@ router.get('/:id/fetch-stream', async (req, res) => {
     send({ phase: 'saving', message: `Saving cache (${channels.length} channels)…` });
     const { cachePath, size } = saveEPGCache(DATA_DIR, src.id, buf);
     storeEPGChannels(src.id, channels, cachePath, size);
+    queueGuideIndex(src.id, cachePath);
     // Clear guide cache so next guide load is fresh
     try { require('./guide').clearCache(); } catch {}
 
@@ -163,6 +165,7 @@ router.post('/:id/fetch', async (req, res) => {
 
     const programmeCount = countProgrammeEntriesFromBuffer(fs.readFileSync(cachePath));
     storeEPGChannels(src.id, channels, cachePath, size, programmeCount);
+    queueGuideIndex(src.id, cachePath);
     try { require('./guide').clearCache(); } catch {}
     logger.info('epg', 'Manual EPG source fetch success', { source_id: src.id, channels: channels.length, programmes: programmeCount });
     res.json({ loaded: channels.length, cache_size: size, cached: true, programme_count: programmeCount });
@@ -186,6 +189,7 @@ router.post('/:id/upload', async (req, res) => {
     const { cachePath, size } = saveEPGCache(DATA_DIR, src.id, buf);
     const programmeCount = countProgrammeEntriesFromBuffer(buf);
     storeEPGChannels(src.id, channels, cachePath, size, programmeCount);
+    queueGuideIndex(src.id, cachePath);
     try { require('./guide').clearCache(); } catch {}
     logger.info('epg', 'Manual EPG source fetch success', { source_id: src.id, channels: channels.length, programmes: programmeCount });
     res.json({ loaded: channels.length, cache_size: size, cached: true, programme_count: programmeCount });

--- a/backend/src/routes/guide.js
+++ b/backend/src/routes/guide.js
@@ -1,7 +1,6 @@
 const router = require('express').Router();
 const db     = require('../db');
 const requireAuth = require('../middleware/auth');
-const { readProgrammes } = require('../utils/epg-reader');
 const logger = require('../logger');
 
 router.use(requireAuth);
@@ -67,24 +66,24 @@ router.get('/:playlist_id', async (req, res) => {
   ).all(...args, pageSize, offset);
 
   const sources = db.prepare(
-    'SELECT * FROM epg_sources WHERE user_id = ? AND cache_path IS NOT NULL ORDER BY priority ASC, id ASC'
+    'SELECT id, guide_index_status, guide_index_error, guide_index_updated FROM epg_sources WHERE user_id = ? AND cache_path IS NOT NULL ORDER BY priority ASC, id ASC'
   ).all(req.user.id);
+
+  const sourceIds = sources.map(s => s.id);
+  const sourceStatus = {
+    ready: sources.filter(s => s.guide_index_status === 'ready').length,
+    building: sources.filter(s => s.guide_index_status === 'building').length,
+    failed: sources.filter(s => s.guide_index_status === 'failed').length,
+    total: sources.length,
+    last_error: sources.find(s => s.guide_index_status === 'failed')?.guide_index_error || null,
+  };
 
   const epgIds = [...new Set([
     ...channels.map(c => c.epg_id).filter(Boolean),
     ...channels.map(c => c.backup_epg_id).filter(Boolean),
   ])];
 
-  const cacheKey = JSON.stringify({
-    playlistId,
-    page: safePage,
-    pageSize,
-    group,
-    q: q.toLowerCase(),
-    start: from.toISOString(),
-    end: to.toISOString(),
-    ids: epgIds,
-  });
+  const cacheKey = JSON.stringify({ playlistId, page: safePage, pageSize, group, q: q.toLowerCase(), start: from.toISOString(), end: to.toISOString(), ids: epgIds, sourceIds, src: sourceStatus });
   const cached = cache.get(cacheKey);
   if (cached && (Date.now() - cached.ts) < CACHE_TTL) return res.json(cached.data);
 
@@ -92,18 +91,29 @@ router.get('/:playlist_id', async (req, res) => {
   const allProgs = new Map();
   epgIds.forEach(id => allProgs.set(id, []));
 
-  for (const src of sources) {
-    if (!epgIds.length) break;
-    try {
-      const results = await readProgrammes(src.cache_path, epgIds, { from, to, max: 50 });
-      results.forEach((progs, epgId) => {
-        const existing = allProgs.get(epgId) || [];
-        const startKeys = new Set(existing.map(p => p.start?.getTime()));
-        const deduped = progs.filter(p => !startKeys.has(p.start?.getTime()));
-        allProgs.set(epgId, [...existing, ...deduped]);
+  if (epgIds.length && sourceIds.length) {
+    const placeholdersEpg = epgIds.map(() => '?').join(',');
+    const placeholdersSrc = sourceIds.map(() => '?').join(',');
+    const rows = db.prepare(
+      `SELECT epg_id, start, stop, title, subtitle, desc, category
+       FROM guide_programmes
+       WHERE source_id IN (${placeholdersSrc})
+         AND epg_id IN (${placeholdersEpg})
+         AND stop > ? AND start < ?
+       ORDER BY start ASC`
+    ).all(...sourceIds, ...epgIds, from.toISOString(), to.toISOString());
+
+    for (const r of rows) {
+      const list = allProgs.get(r.epg_id) || [];
+      list.push({
+        title: r.title,
+        subtitle: r.subtitle,
+        desc: r.desc,
+        category: r.category,
+        start: r.start ? new Date(r.start) : null,
+        stop: r.stop ? new Date(r.stop) : null,
       });
-    } catch (e) {
-      logger.warn('epg', 'Guide EPG source read failed', { sourceId: src.id, sourceName: src.name, error: e.message });
+      allProgs.set(r.epg_id, list);
     }
   }
 
@@ -121,6 +131,7 @@ router.get('/:playlist_id', async (req, res) => {
     total,
     total_pages: totalPages,
     count: channels.length,
+    guide_index: sourceStatus,
     channels: channels.map(ch => ({
       id: ch.id,
       name: ch.name,

--- a/backend/src/routes/guide.js
+++ b/backend/src/routes/guide.js
@@ -2,113 +2,180 @@ const router = require('express').Router();
 const db     = require('../db');
 const requireAuth = require('../middleware/auth');
 const { readProgrammes } = require('../utils/epg-reader');
+const logger = require('../logger');
 
 router.use(requireAuth);
 
-// Simple in-memory cache: key = `${playlistId}:${dateKey}` → { data, ts }
 const cache = new Map();
-const CACHE_TTL = 10 * 60 * 1000; // 10 minutes
+const CACHE_TTL = 10 * 60 * 1000;
+const DEFAULT_PAGE_SIZE = 50;
+const VALID_PAGE_SIZES = new Set([25, 50, 100, 200]);
+const DEFAULT_WINDOW_HOURS = 24;
 
-router.get('/', async (req, res) => {
-  const { playlist_id, hours = 6, from_offset = 0 } = req.query;
-  if (!playlist_id) return res.status(400).json({ error: 'playlist_id required' });
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
-  const pl = db.prepare('SELECT * FROM playlists WHERE id = ? AND user_id = ?').get(playlist_id, req.user.id);
+function parseDate(value, fallback) {
+  if (!value) return fallback;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? fallback : d;
+}
+
+router.get('/:playlist_id', async (req, res) => {
+  const playlistId = Number.parseInt(req.params.playlist_id, 10);
+  if (!playlistId) return res.status(400).json({ error: 'playlist_id required' });
+
+  const pl = db.prepare('SELECT * FROM playlists WHERE id = ? AND user_id = ?').get(playlistId, req.user.id);
   if (!pl) return res.status(404).json({ error: 'Not found' });
 
-  // Build time window
-  const from = new Date();
-  from.setMinutes(from.getMinutes() - 30, 0, 0);
-  if (Number(from_offset)) from.setHours(from.getHours() + Number(from_offset));
-  const to = new Date(from.getTime() + (Number(hours) + 1) * 3600000);
+  const page = parsePositiveInt(req.query.page, 1);
+  const requestedPageSize = parsePositiveInt(req.query.page_size, DEFAULT_PAGE_SIZE);
+  const pageSize = VALID_PAGE_SIZES.has(requestedPageSize) ? requestedPageSize : DEFAULT_PAGE_SIZE;
+  const group = typeof req.query.group === 'string' ? req.query.group : '__all__';
+  const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
 
-  // Cache key based on playlist + hour window
-  const cacheKey = `${playlist_id}:${Math.floor(from.getTime() / (30 * 60000))}`;
-  const cached   = cache.get(cacheKey);
-  if (cached && (Date.now() - cached.ts) < CACHE_TTL) {
-    return res.json(cached.data);
+  const now = new Date();
+  const defaultStart = new Date(now.getTime() - 30 * 60000);
+  const defaultEnd = new Date(defaultStart.getTime() + DEFAULT_WINDOW_HOURS * 3600000);
+  const from = parseDate(req.query.start, defaultStart);
+  const to = parseDate(req.query.end, defaultEnd);
+
+  const where = ['playlist_id = ?', 'enabled = 1'];
+  const args = [playlistId];
+
+  if (group && group !== '__all__') {
+    where.push('grp = ?');
+    args.push(group);
   }
 
+  if (q) {
+    where.push('(LOWER(name) LIKE ? OR LOWER(tvg_id) LIKE ? OR LOWER(epg_id) LIKE ? OR LOWER(backup_epg_id) LIKE ?)');
+    const like = `%${q.toLowerCase()}%`;
+    args.push(like, like, like, like);
+  }
+
+  const whereSql = where.join(' AND ');
+  const total = db.prepare(`SELECT COUNT(*) as total FROM channels WHERE ${whereSql}`).get(...args)?.total || 0;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const safePage = Math.min(page, totalPages);
+  const offset = (safePage - 1) * pageSize;
+
   const channels = db.prepare(
-    'SELECT * FROM channels WHERE playlist_id = ? AND enabled = 1 ORDER BY ord ASC, id ASC'
-  ).all(playlist_id);
+    `SELECT * FROM channels WHERE ${whereSql} ORDER BY ord ASC, id ASC LIMIT ? OFFSET ?`
+  ).all(...args, pageSize, offset);
 
   const sources = db.prepare(
     'SELECT * FROM epg_sources WHERE user_id = ? AND cache_path IS NOT NULL ORDER BY priority ASC, id ASC'
   ).all(req.user.id);
 
-  // Collect all IDs we need to look up (primary + backup)
   const epgIds = [...new Set([
     ...channels.map(c => c.epg_id).filter(Boolean),
     ...channels.map(c => c.backup_epg_id).filter(Boolean),
   ])];
+
+  const cacheKey = JSON.stringify({
+    playlistId,
+    page: safePage,
+    pageSize,
+    group,
+    q: q.toLowerCase(),
+    start: from.toISOString(),
+    end: to.toISOString(),
+    ids: epgIds,
+  });
+  const cached = cache.get(cacheKey);
+  if (cached && (Date.now() - cached.ts) < CACHE_TTL) return res.json(cached.data);
+
+  const t0 = Date.now();
   const allProgs = new Map();
   epgIds.forEach(id => allProgs.set(id, []));
 
-  // Read each cache file once for all channels
   for (const src of sources) {
     if (!epgIds.length) break;
     try {
-      const results = await readProgrammes(src.cache_path, epgIds, { from, to, max: 25 });
+      const results = await readProgrammes(src.cache_path, epgIds, { from, to, max: 50 });
       results.forEach((progs, epgId) => {
         const existing = allProgs.get(epgId) || [];
-        // Deduplicate by start time
         const startKeys = new Set(existing.map(p => p.start?.getTime()));
-        const newProgs  = progs.filter(p => !startKeys.has(p.start?.getTime()));
-        allProgs.set(epgId, [...existing, ...newProgs]);
+        const deduped = progs.filter(p => !startKeys.has(p.start?.getTime()));
+        allProgs.set(epgId, [...existing, ...deduped]);
       });
     } catch (e) {
-      console.error('[guide] Error reading', src.name, e.message);
+      logger.warn('epg', 'Guide EPG source read failed', { sourceId: src.id, sourceName: src.name, error: e.message });
     }
   }
 
-  // For each channel: use primary epg_id programmes, fall back to backup_epg_id if primary empty
   const getProgs = (ch) => {
-    const primary  = ch.epg_id      ? (allProgs.get(ch.epg_id)      || []) : [];
-    const backup   = ch.backup_epg_id ? (allProgs.get(ch.backup_epg_id) || []) : [];
+    const primary = ch.epg_id ? (allProgs.get(ch.epg_id) || []) : [];
+    const backup = ch.backup_epg_id ? (allProgs.get(ch.backup_epg_id) || []) : [];
     return primary.length > 0 ? primary : backup;
   };
 
-  // Sort: channels with EPG data first so progressive load shows useful content immediately
-  const channelsWithEpg    = channels.filter(ch => getProgs(ch).length > 0);
-  const channelsWithoutEpg = channels.filter(ch => getProgs(ch).length === 0);
-  const sortedChannels = [...channelsWithEpg, ...channelsWithoutEpg];
-
   const result = {
-    from:     from.toISOString(),
-    to:       to.toISOString(),
-    channels: sortedChannels.map(ch => ({
-      id:             ch.id,
-      name:           ch.name,
-      tvg_logo:       ch.tvg_logo       || '',
-      epg_id:         ch.epg_id         || '',
-      backup_epg_id:  ch.backup_epg_id  || '',
-      grp:            ch.grp,
-      timeshift:      ch.timeshift || 0,
+    from: from.toISOString(),
+    to: to.toISOString(),
+    page: safePage,
+    page_size: pageSize,
+    total,
+    total_pages: totalPages,
+    count: channels.length,
+    channels: channels.map(ch => ({
+      id: ch.id,
+      name: ch.name,
+      tvg_id: ch.tvg_id || '',
+      tvg_logo: ch.tvg_logo || '',
+      epg_id: ch.epg_id || '',
+      backup_epg_id: ch.backup_epg_id || '',
+      grp: ch.grp,
+      timeshift: ch.timeshift || 0,
       programmes: getProgs(ch)
         .sort((a, b) => (a.start || 0) - (b.start || 0))
         .map(p => ({
-          title:    p.title,
+          title: p.title,
           subtitle: p.subtitle || '',
-          desc:     p.desc     || '',
+          desc: p.desc || '',
           category: p.category || '',
-          start:    p.start?.toISOString() || null,
-          stop:     p.stop?.toISOString()  || null,
+          start: p.start?.toISOString() || null,
+          stop: p.stop?.toISOString() || null,
         })),
     })),
   };
 
   cache.set(cacheKey, { data: result, ts: Date.now() });
+  for (const [k, v] of cache) if (Date.now() - v.ts > CACHE_TTL * 2) cache.delete(k);
 
-  // Clean old cache entries
-  for (const [k, v] of cache) {
-    if (Date.now() - v.ts > CACHE_TTL * 2) cache.delete(k);
+  const elapsed = Date.now() - t0;
+  logger.info('epg', 'Guide page loaded', {
+    playlistId,
+    page: safePage,
+    pageSize,
+    total,
+    channelsReturned: channels.length,
+    epgIdCount: epgIds.length,
+    sourceCount: sources.length,
+    from: from.toISOString(),
+    to: to.toISOString(),
+    elapsedMs: elapsed,
+    filteredByGroup: group !== '__all__',
+    hasQuery: Boolean(q),
+  });
+
+  if (elapsed > 2000 || total > 5000) {
+    logger.warn('epg', 'Heavy guide load detected', {
+      playlistId,
+      elapsedMs: elapsed,
+      totalChannels: total,
+      pageSize,
+      page: safePage,
+      epgIdCount: epgIds.length,
+    });
   }
 
   res.json(result);
 });
 
-// DELETE /api/guide/cache — invalidate guide cache (call after EPG refresh)
 router.delete('/cache', (req, res) => {
   cache.clear();
   res.json({ ok: true });

--- a/backend/src/routes/guide.js
+++ b/backend/src/routes/guide.js
@@ -44,6 +44,15 @@ router.get('/:playlist_id', async (req, res) => {
   const where = ['playlist_id = ?', 'enabled = 1'];
   const args = [playlistId];
 
+  const groupRows = db.prepare(`
+    SELECT grp AS name, COUNT(*) AS count
+    FROM channels
+    WHERE playlist_id = ? AND enabled = 1 AND grp IS NOT NULL AND grp != ''
+    GROUP BY grp
+    ORDER BY grp COLLATE NOCASE ASC
+  `).all(playlistId);
+
+
   if (group && group !== '__all__') {
     where.push('grp = ?');
     args.push(group);
@@ -132,6 +141,7 @@ router.get('/:playlist_id', async (req, res) => {
     total_pages: totalPages,
     count: channels.length,
     guide_index: sourceStatus,
+    groups: groupRows,
     channels: channels.map(ch => ({
       id: ch.id,
       name: ch.name,

--- a/backend/src/scheduler.js
+++ b/backend/src/scheduler.js
@@ -47,7 +47,6 @@ async function refreshPlaylist(pl) {
       db.prepare("UPDATE playlists SET last_refreshed=datetime('now'), updated_at=datetime('now') WHERE id=?").run(pl.id);
     })();
 
-    queueGuideIndex(src.id, cachePath);
 
     console.log(`[scheduler] Playlist "${pl.name}" refreshed — ${counts.importedLive}/${counts.totalEntries} live channels imported (${counts.skippedVodLike} VOD-like entries skipped)`);
     logger.info('scheduler','Playlist scheduled refresh success',{ playlist_id: pl.id, imported_live: counts.importedLive, total_entries: counts.totalEntries });
@@ -86,7 +85,6 @@ async function refreshEPGSource(src) {
       `).run(channels.length, programmeCount, cachePath, size, src.id);
     })();
 
-    queueGuideIndex(src.id, cachePath);
 
     console.log(`[scheduler] EPG source "${src.name}" refreshed — ${channels.length} channels, ${programmeCount} programmes, ${(size/1024/1024).toFixed(1)} MB`);
     logger.info('epg','EPG source fetch success',{ source_id: src.id, channels: channels.length, programmes: programmeCount });

--- a/backend/src/scheduler.js
+++ b/backend/src/scheduler.js
@@ -12,6 +12,7 @@ const { saveEPGCache } = require('./utils/xmltv-merge');
 const { countProgrammeEntriesFromBuffer } = require('./utils/xmltv-programme-count');
 const { buildHttpStatusError, getPlaylistFetchErrorMessage } = require('./utils/http-errors');
 const logger = require('./logger');
+const { queueGuideIndex } = require('./utils/guide-indexer');
 
 const DATA_DIR    = process.env.DATA_DIR || './data';
 const CHECK_EVERY = 15 * 60 * 1000; // 15 minutes
@@ -45,6 +46,8 @@ async function refreshPlaylist(pl) {
       channels.forEach((c, i) => insert.run({ ...c, playlist_id: pl.id, ord: i }));
       db.prepare("UPDATE playlists SET last_refreshed=datetime('now'), updated_at=datetime('now') WHERE id=?").run(pl.id);
     })();
+
+    queueGuideIndex(src.id, cachePath);
 
     console.log(`[scheduler] Playlist "${pl.name}" refreshed — ${counts.importedLive}/${counts.totalEntries} live channels imported (${counts.skippedVodLike} VOD-like entries skipped)`);
     logger.info('scheduler','Playlist scheduled refresh success',{ playlist_id: pl.id, imported_live: counts.importedLive, total_entries: counts.totalEntries });
@@ -82,6 +85,8 @@ async function refreshEPGSource(src) {
         WHERE id=?
       `).run(channels.length, programmeCount, cachePath, size, src.id);
     })();
+
+    queueGuideIndex(src.id, cachePath);
 
     console.log(`[scheduler] EPG source "${src.name}" refreshed — ${channels.length} channels, ${programmeCount} programmes, ${(size/1024/1024).toFixed(1)} MB`);
     logger.info('epg','EPG source fetch success',{ source_id: src.id, channels: channels.length, programmes: programmeCount });

--- a/backend/src/utils/guide-indexer.js
+++ b/backend/src/utils/guide-indexer.js
@@ -10,8 +10,25 @@ function setStatus(sourceId, status, message = null) {
     .run(status, message, sourceId);
 }
 
+const pending = new Set();
+
 function queueGuideIndex(sourceId, cachePath) {
-  setImmediate(() => buildGuideIndex(sourceId, cachePath).catch(() => {}));
+  const key = String(sourceId);
+  if (pending.has(key)) return;
+  pending.add(key);
+  setImmediate(() => buildGuideIndex(sourceId, cachePath).catch(() => {}).finally(() => pending.delete(key)));
+}
+
+function queueStaleGuideIndexes() {
+  const stale = db.prepare(`
+    SELECT id, cache_path
+    FROM epg_sources
+    WHERE cache_path IS NOT NULL
+      AND cache_path != ''
+      AND (guide_index_status IS NULL OR guide_index_status IN ('idle','failed'))
+  `).all();
+  stale.forEach(src => queueGuideIndex(src.id, src.cache_path));
+  if (stale.length) logger.info('epg', 'Queued stale guide indexes on startup', { sourceCount: stale.length });
 }
 
 async function buildGuideIndex(sourceId, cachePath) {
@@ -26,7 +43,13 @@ async function buildGuideIndex(sourceId, cachePath) {
 
     db.transaction(() => del.run(sourceId))();
 
+    const BATCH_SIZE = 1000;
+    const flushBatch = db.transaction((rows) => {
+      for (const r of rows) ins.run(sourceId, r.epgId, r.start, r.stop, r.title, r.subtitle, r.desc, r.category);
+    });
+
     let count = 0;
+    let batch = [];
     await new Promise((resolve, reject) => {
       const parser = sax.createStream(true);
       let inProg = false; let cur = null; let field = null;
@@ -52,14 +75,15 @@ async function buildGuideIndex(sourceId, cachePath) {
         if (['title','desc','category','sub-title'].includes(name)) field = null;
         if (name === 'programme' && inProg && cur) {
           if (cur.start && cur.stop) {
-            ins.run(sourceId, cur.epgId, cur.start.toISOString(), cur.stop.toISOString(), cur.title, cur.subtitle, cur.desc, cur.category);
+            batch.push({ epgId: cur.epgId, start: cur.start.toISOString(), stop: cur.stop.toISOString(), title: cur.title, subtitle: cur.subtitle, desc: cur.desc, category: cur.category });
             count += 1;
+            if (batch.length >= BATCH_SIZE) { flushBatch(batch); batch = []; }
           }
           inProg = false; cur = null;
         }
       });
       parser.on('error', reject);
-      parser.on('end', resolve);
+      parser.on('end', () => { if (batch.length) flushBatch(batch); resolve(); });
       const buf = fs.readFileSync(cachePath);
       const isGzip = buf[0] === 0x1f && buf[1] === 0x8b;
       const source = Readable.from(buf);
@@ -83,4 +107,4 @@ function parseXMLTVTime(str) {
   return new Date(`${yr}-${mo}-${dy}T${hr}:${mn}:${sc}${off}`);
 }
 
-module.exports = { queueGuideIndex };
+module.exports = { queueGuideIndex, queueStaleGuideIndexes };

--- a/backend/src/utils/guide-indexer.js
+++ b/backend/src/utils/guide-indexer.js
@@ -1,0 +1,86 @@
+const fs = require('fs');
+const sax = require('sax');
+const zlib = require('zlib');
+const { Readable } = require('stream');
+const db = require('../db');
+const logger = require('../logger');
+
+function setStatus(sourceId, status, message = null) {
+  db.prepare('UPDATE epg_sources SET guide_index_status=?, guide_index_error=?, guide_index_updated=datetime(\'now\') WHERE id=?')
+    .run(status, message, sourceId);
+}
+
+function queueGuideIndex(sourceId, cachePath) {
+  setImmediate(() => buildGuideIndex(sourceId, cachePath).catch(() => {}));
+}
+
+async function buildGuideIndex(sourceId, cachePath) {
+  const start = Date.now();
+  setStatus(sourceId, 'building', null);
+  logger.info('epg', 'Guide index start', { sourceId });
+  try {
+    if (!cachePath || !fs.existsSync(cachePath)) throw new Error('EPG cache file not found');
+
+    const del = db.prepare('DELETE FROM guide_programmes WHERE source_id = ?');
+    const ins = db.prepare('INSERT INTO guide_programmes (source_id, epg_id, start, stop, title, subtitle, desc, category) VALUES (?,?,?,?,?,?,?,?)');
+
+    db.transaction(() => del.run(sourceId))();
+
+    let count = 0;
+    await new Promise((resolve, reject) => {
+      const parser = sax.createStream(true);
+      let inProg = false; let cur = null; let field = null;
+      parser.on('opentag', (node) => {
+        if (node.name === 'programme') {
+          const epgId = String(node.attributes.channel || '').trim();
+          const start = String(node.attributes.start || '');
+          const stop = String(node.attributes.stop || '');
+          if (!epgId || !start || !stop) return;
+          inProg = true;
+          cur = { epgId, start: parseXMLTVTime(start), stop: parseXMLTVTime(stop), title: '', subtitle: '', desc: '', category: '' };
+        } else if (inProg && ['title','desc','category','sub-title'].includes(node.name)) field = node.name;
+      });
+      parser.on('text', (text) => {
+        if (!inProg || !field || !cur) return;
+        const t = text.trim(); if (!t) return;
+        if (field === 'title') cur.title += t;
+        if (field === 'desc') cur.desc += t;
+        if (field === 'category') cur.category += t;
+        if (field === 'sub-title') cur.subtitle += t;
+      });
+      parser.on('closetag', (name) => {
+        if (['title','desc','category','sub-title'].includes(name)) field = null;
+        if (name === 'programme' && inProg && cur) {
+          if (cur.start && cur.stop) {
+            ins.run(sourceId, cur.epgId, cur.start.toISOString(), cur.stop.toISOString(), cur.title, cur.subtitle, cur.desc, cur.category);
+            count += 1;
+          }
+          inProg = false; cur = null;
+        }
+      });
+      parser.on('error', reject);
+      parser.on('end', resolve);
+      const buf = fs.readFileSync(cachePath);
+      const isGzip = buf[0] === 0x1f && buf[1] === 0x8b;
+      const source = Readable.from(buf);
+      if (isGzip) source.pipe(zlib.createGunzip()).pipe(parser);
+      else source.pipe(parser);
+    });
+
+    setStatus(sourceId, 'ready', null);
+    logger.info('epg', 'Guide index success', { sourceId, programmeCount: count, elapsedMs: Date.now() - start });
+  } catch (e) {
+    setStatus(sourceId, 'failed', e.message);
+    logger.error('epg', 'Guide index failure', { sourceId, error: e.message, elapsedMs: Date.now() - start });
+  }
+}
+
+function parseXMLTVTime(str) {
+  const m = String(str || '').match(/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})\s*([+-]\d{4})?/);
+  if (!m) return null;
+  const [, yr, mo, dy, hr, mn, sc, tz] = m;
+  const off = tz ? tz.slice(0,3) + ':' + tz.slice(3) : 'Z';
+  return new Date(`${yr}-${mo}-${dy}T${hr}:${mn}:${sc}${off}`);
+}
+
+module.exports = { queueGuideIndex };

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -127,9 +127,14 @@ export const playlists_extra = {
 };
 
 export const guide = {
-  load:         (playlist_id, hours = 6, from_offset = 0) =>
-    get(`/guide?playlist_id=${playlist_id}&hours=${hours}&from_offset=${from_offset}`),
-  clearCache:   () => del('/guide/cache'),
+  load: (playlistId, params = {}) => {
+    const query = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') query.set(key, String(value));
+    });
+    return get(`/guide/${playlistId}?${query.toString()}`);
+  },
+  clearCache: () => del('/guide/cache'),
 };
 
 export const scraper = {

--- a/frontend/src/pages/Guide.jsx
+++ b/frontend/src/pages/Guide.jsx
@@ -24,6 +24,7 @@ export default function Guide() {
   const [playlists,  setPlaylists]  = useState([]);
   const [playlist,   setPlaylist]   = useState(null);
   const [data,       setData]       = useState(null);
+  const [channelsData,setChannelsData]= useState([]);
   const [paging,     setPaging]     = useState({ page: 1, pageSize: 50, total: 0, totalPages: 1 });
   const [groupFilter,setGroupFilter]= useState('__all__');
   const [search,     setSearch]     = useState('');
@@ -49,23 +50,25 @@ export default function Guide() {
     plApi.list().then(setPlaylists).catch(() => {});
   }, []);
 
-  const load = useCallback(async (playlistId) => {
+  const load = useCallback(async (playlistId, targetPage = 1, append = false) => {
     setLoading(true);
     try {
       const start = viewStart.toISOString();
       const end = new Date(viewStart.getTime() + windowHours * 3600000).toISOString();
       const [pl, guideData] = await Promise.all([
         plApi.get(playlistId),
-        guideApi.load(playlistId, { page: paging.page, page_size: paging.pageSize, group: groupFilter, q: search, start, end }),
+        guideApi.load(playlistId, { page: targetPage, page_size: paging.pageSize, group: groupFilter, q: search, start, end }),
       ]);
       setPlaylist(pl);
       setData(guideData);
-      setPaging(p => ({ ...p, total: guideData.total || 0, totalPages: guideData.total_pages || 1, page: guideData.page || p.page }));
+      setChannelsData(prev => append ? [...prev, ...(guideData.channels || [])] : (guideData.channels || []));
+      setPaging(p => ({ ...p, total: guideData.total || 0, totalPages: guideData.total_pages || 1, page: guideData.page || targetPage }));
     } catch (e) { toast(e.message, 'error'); }
     finally { setLoading(false); }
-  }, [paging.page, paging.pageSize, groupFilter, search, viewStart, windowHours, toast]);
+  }, [paging.pageSize, groupFilter, search, viewStart, windowHours, toast]);
 
-  useEffect(() => { load(id); }, [id, load]);
+  useEffect(() => { setPaging(p => ({ ...p, page: 1 })); load(id, 1, false); }, [id, groupFilter, search, viewStart, windowHours, paging.pageSize]);
+
 
   // Scroll to now after load
   useEffect(() => {
@@ -115,7 +118,7 @@ export default function Guide() {
   };
 
   // Filtered channels
-  const channels = useMemo(() => data?.channels || [], [data]);
+  const channels = useMemo(() => channelsData, [channelsData]);
 
   const groups = useMemo(() => data?.groups || [], [data]);
 
@@ -157,13 +160,13 @@ export default function Guide() {
         {/* Search */}
         <div className="flex gap-1" style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: 6, padding: '4px 8px', width: 200 }}>
           <Search size={12} color="var(--faint)" />
-          <input value={search} onChange={e => { setSearch(e.target.value); setPaging(p => ({ ...p, page: 1 })); }} placeholder="Search channel or show…"
+          <input value={search} onChange={e => { setSearch(e.target.value); }} placeholder="Search channel or show…"
             style={{ background: 'transparent', border: 'none', outline: 'none', color: 'var(--text)', fontSize: 12, width: '100%', fontFamily: 'inherit' }} />
-          {search && <button onClick={() => { setSearch(''); setPaging(p => ({ ...p, page: 1 })); }} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'var(--faint)' }}><X size={11}/></button>}
+          {search && <button onClick={() => { setSearch(''); }} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'var(--faint)' }}><X size={11}/></button>}
         </div>
 
         {/* Group filter */}
-        <select className="input" value={groupFilter} onChange={e => { setGroupFilter(e.target.value); setPaging(p => ({ ...p, page: 1 })); }}
+        <select className="input" value={groupFilter} onChange={e => { setGroupFilter(e.target.value); }}
           style={{ width: 150, fontSize: 12, padding: '4px 8px' }}>
           <option value="__all__">All groups</option>
           {groups.map(g => <option key={g.name} value={g.name}>{g.name} ({g.count})</option>)}
@@ -180,25 +183,24 @@ export default function Guide() {
         <button className="btn btn-ghost btn-icon btn-sm" onClick={() => shiftView(-1)}><ChevronLeft size={14}/></button>
         <button className="btn btn-ghost btn-icon btn-sm" onClick={() => shiftView(1)}><ChevronRight size={14}/></button>
 
-        <span className="text-muted text-sm">Showing {paging.total === 0 ? 0 : ((paging.page - 1) * paging.pageSize) + 1}-{Math.min(paging.page * paging.pageSize, paging.total)} of {paging.total.toLocaleString()}</span>
-        <select className="input" value={paging.pageSize} onChange={e => setPaging(p => ({ ...p, pageSize: Number(e.target.value), page: 1 }))}
+        <span className="text-muted text-sm">Showing {channels.length === 0 ? 0 : 1}-{channels.length} of {paging.total.toLocaleString()}</span>
+        <select className="input" title="Batch size" value={paging.pageSize} onChange={e => setPaging(p => ({ ...p, pageSize: Number(e.target.value) }))}
           style={{ width: 80, fontSize: 12, padding: '4px 8px' }}>
           {[25,50,100,200].map(sz => <option key={sz} value={sz}>{sz}</option>)}
         </select>
-        <button className="btn btn-ghost btn-icon btn-sm" disabled={paging.page <= 1} onClick={() => setPaging(p => ({ ...p, page: Math.max(1, p.page - 1) }))}><ChevronLeft size={14}/></button>
-        <button className="btn btn-ghost btn-icon btn-sm" disabled={paging.page >= paging.totalPages} onClick={() => setPaging(p => ({ ...p, page: Math.min(p.totalPages, p.page + 1) }))}><ChevronRight size={14}/></button>
+        <button className="btn btn-ghost btn-sm" disabled={loading || paging.page >= paging.totalPages} onClick={() => load(id, paging.page + 1, true)}>Load more</button>
 
-        <select className="input" value={windowHours} onChange={e => { setWindowHours(Number(e.target.value)); setPaging(p => ({ ...p, page: 1 })); }} style={{ width: 90, fontSize: 12, padding: "4px 8px" }}><option value={12}>12h</option><option value={24}>24h</option></select>
+        <select className="input" value={windowHours} onChange={e => { setWindowHours(Number(e.target.value)); }} style={{ width: 90, fontSize: 12, padding: "4px 8px" }}><option value={12}>12h</option><option value={24}>24h</option></select>
         <ThemeToggle />
         <button className="btn btn-ghost btn-sm" onClick={() => nav('/settings')}><Settings size={13}/></button>
           <HeaderButtons />
-        <button className="btn btn-ghost btn-icon btn-sm" title="Refresh" onClick={() => load(id)}><RefreshCw size={13}/></button>
+        <button className="btn btn-ghost btn-icon btn-sm" title="Refresh" onClick={() => load(id, 1, false)}><RefreshCw size={13}/></button>
       </header>
 
 
       {data?.guide_index?.building > 0 && (
         <div style={{ padding: '8px 12px', fontSize: 12, color: 'var(--muted)', borderBottom: '1px solid var(--border2)' }}>
-          Guide index is building… ({data.guide_index.building}/{data.guide_index.total} sources)
+          Guide index is building. The first load after an EPG update may be slower. The Guide will be faster once indexing is complete. ({data.guide_index.building}/{data.guide_index.total} sources)
         </div>
       )}
       {data?.guide_index?.failed > 0 && (

--- a/frontend/src/pages/Guide.jsx
+++ b/frontend/src/pages/Guide.jsx
@@ -10,7 +10,8 @@ import { useTZ } from '../timezone.jsx';
 const HOUR_WIDTH  = 260;
 const ROW_HEIGHT  = 54;
 const LABEL_WIDTH = 190;
-const HOURS       = 6;
+const DEFAULT_WINDOW_HOURS = 24;
+const GUIDE_VIEW_HOURS = 6;
 
 export default function Guide() {
   const { id }    = useParams();
@@ -23,11 +24,13 @@ export default function Guide() {
   const [playlists,  setPlaylists]  = useState([]);
   const [playlist,   setPlaylist]   = useState(null);
   const [data,       setData]       = useState(null);
+  const [paging,     setPaging]     = useState({ page: 1, pageSize: 50, total: 0, totalPages: 1 });
+  const [groupFilter,setGroupFilter]= useState('__all__');
+  const [search,     setSearch]     = useState('');
+  const [windowHours,setWindowHours]= useState(DEFAULT_WINDOW_HOURS);
   const [loading,    setLoading]    = useState(true);
   const [selected,   setSelected]   = useState(null);
   const [now,        setNow]        = useState(new Date());
-  const [search,     setSearch]     = useState('');
-  const [groupFilter,setGroupFilter]= useState('__all__');
   const [tsEdit,     setTsEdit]     = useState(null);   // { channelId, current }
   const [savingTs,   setSavingTs]   = useState(false);
 
@@ -46,60 +49,23 @@ export default function Guide() {
     plApi.list().then(setPlaylists).catch(() => {});
   }, []);
 
-  // Frontend cache: playlist_id -> guide data
-  const guideCache = useRef({});
-  const fullData   = useRef(null); // always holds complete channel list
-
-  const load = useCallback(async (playlistId, forceRefresh = false) => {
-    // Return cached data instantly while refreshing in background
-    if (!forceRefresh && guideCache.current[playlistId]) {
-      setData(guideCache.current[playlistId]);
-      setLoading(false);
-      // Still refresh in background silently
-      guideApi.load(playlistId, HOURS + 1)
-        .then(guideData => {
-          guideCache.current[playlistId] = guideData;
-          setData(guideData);
-        })
-        .catch(() => {});
-      return;
-    }
-
+  const load = useCallback(async (playlistId) => {
     setLoading(true);
     try {
-      // Load playlist info and first batch of channels in parallel
+      const start = viewStart.toISOString();
+      const end = new Date(viewStart.getTime() + windowHours * 3600000).toISOString();
       const [pl, guideData] = await Promise.all([
         plApi.get(playlistId),
-        guideApi.load(playlistId, HOURS + 1),
+        guideApi.load(playlistId, { page: paging.page, page_size: paging.pageSize, group: groupFilter, q: search, start, end }),
       ]);
       setPlaylist(pl);
+      setData(guideData);
+      setPaging(p => ({ ...p, total: guideData.total || 0, totalPages: guideData.total_pages || 1, page: guideData.page || p.page }));
+    } catch (e) { toast(e.message, 'error'); }
+    finally { setLoading(false); }
+  }, [paging.page, paging.pageSize, groupFilter, search, viewStart, windowHours, toast]);
 
-      // Show first 30 channels immediately
-      const BATCH = 30;
-      if (guideData.channels.length > BATCH) {
-        setData({ ...guideData, channels: guideData.channels.slice(0, BATCH) });
-        setLoading(false);
-
-        // Load rest in batches of 50
-        let loaded = BATCH;
-        const total = guideData.channels.length;
-        while (loaded < total) {
-          await new Promise(r => setTimeout(r, 50)); // yield to browser
-          const next = Math.min(loaded + 50, total);
-          setData({ ...guideData, channels: guideData.channels.slice(0, next) });
-          loaded = next;
-        }
-      } else {
-        setData(guideData);
-        setLoading(false);
-      }
-
-      guideCache.current[playlistId] = guideData;
-      fullData.current = guideData;
-    } catch (e) { toast(e.message, 'error'); setLoading(false); }
-  }, []);
-
-  useEffect(() => { load(id); }, [id]);
+  useEffect(() => { load(id); }, [id, load]);
 
   // Scroll to now after load
   useEffect(() => {
@@ -111,7 +77,7 @@ export default function Guide() {
     }
   }, [loading]);
 
-  const viewEnd = useMemo(() => new Date(viewStart.getTime() + HOURS * 3600000), [viewStart]);
+  const viewEnd = useMemo(() => new Date(viewStart.getTime() + GUIDE_VIEW_HOURS * 3600000), [viewStart]);
 
   function timeToX(date, base = viewStart) {
     return ((date - base) / 3600000) * HOUR_WIDTH;
@@ -136,7 +102,7 @@ export default function Guide() {
   }, [viewStart, viewEnd]);
 
   const nowX   = timeToX(now);
-  const totalW = HOURS * HOUR_WIDTH;
+  const totalW = GUIDE_VIEW_HOURS * HOUR_WIDTH;
 
   const shiftView   = (h) => setViewStart(v => new Date(v.getTime() + h * 3600000));
   const jumpToDay   = (offset) => {
@@ -149,26 +115,9 @@ export default function Guide() {
   };
 
   // Filtered channels
-  const channels = useMemo(() => {
-    if (!data) return [];
-    let chs = data.channels;
-    if (groupFilter !== '__all__') chs = chs.filter(c => c.grp === groupFilter);
-    if (search) {
-      const q = search.toLowerCase();
-      chs = chs.filter(c =>
-        c.name.toLowerCase().includes(q) ||
-        c.programmes?.some(p => p.title?.toLowerCase().includes(q))
-      );
-    }
-    return chs;
-  }, [data, groupFilter, search]);
+  const channels = useMemo(() => data?.channels || [], [data]);
 
-  const groups = useMemo(() => {
-    // Use fullData so all groups show even during progressive loading
-    const src = fullData.current || data;
-    if (!src) return [];
-    return [...new Set(src.channels.map(c => c.grp))].filter(Boolean).sort();
-  }, [data]);
+  const groups = useMemo(() => [...new Set((data?.channels || []).map(c => c.grp))].filter(Boolean).sort(), [data]);
 
   // Save timeshift from guide
   const saveTimeshift = async (channelId, ts) => {
@@ -208,13 +157,13 @@ export default function Guide() {
         {/* Search */}
         <div className="flex gap-1" style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: 6, padding: '4px 8px', width: 200 }}>
           <Search size={12} color="var(--faint)" />
-          <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Search channel or show…"
+          <input value={search} onChange={e => { setSearch(e.target.value); setPaging(p => ({ ...p, page: 1 })); }} placeholder="Search channel or show…"
             style={{ background: 'transparent', border: 'none', outline: 'none', color: 'var(--text)', fontSize: 12, width: '100%', fontFamily: 'inherit' }} />
-          {search && <button onClick={() => setSearch('')} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'var(--faint)' }}><X size={11}/></button>}
+          {search && <button onClick={() => { setSearch(''); setPaging(p => ({ ...p, page: 1 })); }} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'var(--faint)' }}><X size={11}/></button>}
         </div>
 
         {/* Group filter */}
-        <select className="input" value={groupFilter} onChange={e => setGroupFilter(e.target.value)}
+        <select className="input" value={groupFilter} onChange={e => { setGroupFilter(e.target.value); setPaging(p => ({ ...p, page: 1 })); }}
           style={{ width: 150, fontSize: 12, padding: '4px 8px' }}>
           <option value="__all__">All groups</option>
           {groups.map(g => <option key={g} value={g}>{g}</option>)}
@@ -230,10 +179,20 @@ export default function Guide() {
         <button className="btn btn-ghost btn-sm" onClick={jumpToNow}><Clock size={12}/> Now</button>
         <button className="btn btn-ghost btn-icon btn-sm" onClick={() => shiftView(-1)}><ChevronLeft size={14}/></button>
         <button className="btn btn-ghost btn-icon btn-sm" onClick={() => shiftView(1)}><ChevronRight size={14}/></button>
+
+        <span className="text-muted text-sm">Showing {paging.total === 0 ? 0 : ((paging.page - 1) * paging.pageSize) + 1}-{Math.min(paging.page * paging.pageSize, paging.total)} of {paging.total.toLocaleString()}</span>
+        <select className="input" value={paging.pageSize} onChange={e => setPaging(p => ({ ...p, pageSize: Number(e.target.value), page: 1 }))}
+          style={{ width: 80, fontSize: 12, padding: '4px 8px' }}>
+          {[25,50,100,200].map(sz => <option key={sz} value={sz}>{sz}</option>)}
+        </select>
+        <button className="btn btn-ghost btn-icon btn-sm" disabled={paging.page <= 1} onClick={() => setPaging(p => ({ ...p, page: Math.max(1, p.page - 1) }))}><ChevronLeft size={14}/></button>
+        <button className="btn btn-ghost btn-icon btn-sm" disabled={paging.page >= paging.totalPages} onClick={() => setPaging(p => ({ ...p, page: Math.min(p.totalPages, p.page + 1) }))}><ChevronRight size={14}/></button>
+
+        <select className="input" value={windowHours} onChange={e => { setWindowHours(Number(e.target.value)); setPaging(p => ({ ...p, page: 1 })); }} style={{ width: 90, fontSize: 12, padding: "4px 8px" }}><option value={12}>12h</option><option value={24}>24h</option></select>
         <ThemeToggle />
         <button className="btn btn-ghost btn-sm" onClick={() => nav('/settings')}><Settings size={13}/></button>
           <HeaderButtons />
-        <button className="btn btn-ghost btn-icon btn-sm" title="Refresh" onClick={() => { delete guideCache.current[id]; load(id, true); }}><RefreshCw size={13}/></button>
+        <button className="btn btn-ghost btn-icon btn-sm" title="Refresh" onClick={() => load(id)}><RefreshCw size={13}/></button>
       </header>
 
       {loading ? (

--- a/frontend/src/pages/Guide.jsx
+++ b/frontend/src/pages/Guide.jsx
@@ -117,7 +117,7 @@ export default function Guide() {
   // Filtered channels
   const channels = useMemo(() => data?.channels || [], [data]);
 
-  const groups = useMemo(() => [...new Set((data?.channels || []).map(c => c.grp))].filter(Boolean).sort(), [data]);
+  const groups = useMemo(() => data?.groups || [], [data]);
 
   // Save timeshift from guide
   const saveTimeshift = async (channelId, ts) => {
@@ -166,7 +166,7 @@ export default function Guide() {
         <select className="input" value={groupFilter} onChange={e => { setGroupFilter(e.target.value); setPaging(p => ({ ...p, page: 1 })); }}
           style={{ width: 150, fontSize: 12, padding: '4px 8px' }}>
           <option value="__all__">All groups</option>
-          {groups.map(g => <option key={g} value={g}>{g}</option>)}
+          {groups.map(g => <option key={g.name} value={g.name}>{g.name} ({g.count})</option>)}
         </select>
 
         {/* Day navigation */}

--- a/frontend/src/pages/Guide.jsx
+++ b/frontend/src/pages/Guide.jsx
@@ -121,6 +121,7 @@ export default function Guide() {
 
   // Filtered channels
   const channels = useMemo(() => channelsData, [channelsData]);
+  const contentHeight = 40 + (channels.length * ROW_HEIGHT);
 
   const groups = useMemo(() => data?.groups || [], [data]);
 
@@ -142,10 +143,11 @@ export default function Guide() {
   const syncScroll = (e) => {
     if (labelsRef.current) labelsRef.current.scrollTop = e.currentTarget.scrollTop;
     const el = e.currentTarget;
-    const nearBottom = (el.scrollHeight - el.scrollTop - el.clientHeight) < 240;
+    const nearBottom = (el.scrollTop + el.clientHeight) >= (el.scrollHeight - 300);
     const hasMore = channels.length < paging.total;
-    if (nearBottom && hasMore && !loadingMoreRef.current && !loading) {
-      load(id, paging.page + 1, true);
+    const nextPage = paging.page + 1;
+    if (nearBottom && hasMore && nextPage <= paging.totalPages && !loadingMoreRef.current && !loading) {
+      load(id, nextPage, true);
     }
   };
 
@@ -200,6 +202,7 @@ export default function Guide() {
         <button className="btn btn-ghost btn-sm" disabled={loading || loadingMore || paging.page >= paging.totalPages} onClick={() => load(id, paging.page + 1, true)}>Load more</button>
         {loadingMore && <span className="text-muted text-sm">Loading more…</span>}
 
+        <span className="text-muted text-sm">Showing {windowHours}h window</span>
         <select className="input" value={windowHours} onChange={e => { setWindowHours(Number(e.target.value)); }} style={{ width: 90, fontSize: 12, padding: "4px 8px" }}><option value={12}>12h</option><option value={24}>24h</option></select>
         <ThemeToggle />
         <button className="btn btn-ghost btn-sm" onClick={() => nav('/settings')}><Settings size={13}/></button>
@@ -232,7 +235,7 @@ export default function Guide() {
           {/* Fixed channel labels */}
           <div style={{ width: LABEL_WIDTH, flexShrink: 0, borderRight: '1px solid var(--border2)', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
             <div style={{ height: 40, borderBottom: '1px solid var(--border2)', flexShrink: 0, background: 'var(--surface)' }} />
-            <div ref={labelsRef} style={{ flex: 1, overflowY: 'hidden' }}>
+            <div ref={labelsRef} style={{ flex: 1, overflowY: 'hidden', height: contentHeight - 40 }}>
               {channels.map(ch => (
                 <div key={ch.id} style={{ height: ROW_HEIGHT, display: 'flex', alignItems: 'center', gap: 8, padding: '0 10px', borderBottom: '1px solid var(--border2)', flexShrink: 0 }}>
                   {ch.tvg_logo
@@ -254,7 +257,7 @@ export default function Guide() {
 
           {/* Scrollable grid */}
           <div ref={scrollRef} style={{ flex: 1, overflowX: 'auto', overflowY: 'auto', position: 'relative' }} onScroll={syncScroll}>
-            <div style={{ width: totalW, minHeight: '100%', position: 'relative' }}>
+            <div style={{ width: totalW, height: contentHeight, position: 'relative' }}>
               {/* Time axis */}
               <div style={{ height: 40, position: 'sticky', top: 0, background: 'var(--surface)', borderBottom: '1px solid var(--border2)', zIndex: 10 }}>
                 {/* Date headers at day boundaries */}

--- a/frontend/src/pages/Guide.jsx
+++ b/frontend/src/pages/Guide.jsx
@@ -195,6 +195,18 @@ export default function Guide() {
         <button className="btn btn-ghost btn-icon btn-sm" title="Refresh" onClick={() => load(id)}><RefreshCw size={13}/></button>
       </header>
 
+
+      {data?.guide_index?.building > 0 && (
+        <div style={{ padding: '8px 12px', fontSize: 12, color: 'var(--muted)', borderBottom: '1px solid var(--border2)' }}>
+          Guide index is building… ({data.guide_index.building}/{data.guide_index.total} sources)
+        </div>
+      )}
+      {data?.guide_index?.failed > 0 && (
+        <div style={{ padding: '8px 12px', fontSize: 12, color: '#ff9b9b', borderBottom: '1px solid var(--border2)' }}>
+          Guide index failed for one or more sources. Check logs. {data.guide_index.last_error ? `Last error: ${data.guide_index.last_error}` : ''}
+        </div>
+      )}
+
       {loading ? (
         <div style={{ padding: 32, color: 'var(--muted)' }}>Loading guide…</div>
       ) : channels.length === 0 ? (

--- a/frontend/src/pages/Guide.jsx
+++ b/frontend/src/pages/Guide.jsx
@@ -174,8 +174,8 @@ export default function Guide() {
 
   return (
     <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', background: 'var(--bg)' }}>
-      {/* Header */}
-      <header style={{ background: 'var(--surface)', borderBottom: '1px solid var(--border2)', padding: '0 12px', height: 52, display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0, flexWrap: 'wrap' }}>
+      {/* Top app bar */}
+      <header style={{ background: 'var(--surface)', borderBottom: '1px solid var(--border2)', padding: '0 12px', height: 52, display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
         <button className="btn btn-ghost btn-icon btn-sm" onClick={() => nav(`/edit/${id}`)}><ArrowLeft size={15}/></button>
         <Tv size={15} color="var(--accent)" />
 
@@ -188,6 +188,14 @@ export default function Guide() {
         <span className="text-muted text-sm" style={{ flexShrink: 0 }}>TV Guide</span>
         <div style={{ flex: 1 }} />
 
+        <div style={{ flex: 1 }} />
+        <ThemeToggle />
+        <button className="btn btn-ghost btn-sm" onClick={() => nav('/settings')}><Settings size={13}/></button>
+          <HeaderButtons />
+      </header>
+
+      {/* Guide controls bar */}
+      <div style={{ background: 'var(--surface)', borderBottom: '1px solid var(--border2)', padding: '8px 12px', display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0, flexWrap: 'wrap' }}>
         {/* Search */}
         <div className="flex gap-1" style={{ background: 'var(--surface2)', border: '1px solid var(--border)', borderRadius: 6, padding: '4px 8px', width: 200 }}>
           <Search size={12} color="var(--faint)" />
@@ -225,11 +233,8 @@ export default function Guide() {
 
         <span className="text-muted text-sm">Showing {windowHours}h window: {visibleWindowLabel}</span>
         <select className="input" value={windowHours} onChange={e => { setWindowHours(Number(e.target.value)); if (scrollRef.current) scrollRef.current.scrollLeft = 0; }} style={{ width: 90, fontSize: 12, padding: "4px 8px" }}><option value={12}>12h</option><option value={24}>24h</option></select>
-        <ThemeToggle />
-        <button className="btn btn-ghost btn-sm" onClick={() => nav('/settings')}><Settings size={13}/></button>
-          <HeaderButtons />
         <button className="btn btn-ghost btn-icon btn-sm" title="Refresh" onClick={() => load(id, 1, false)}><RefreshCw size={13}/></button>
-      </header>
+      </div>
 
 
       {data?.guide_index?.building > 0 && (

--- a/frontend/src/pages/Guide.jsx
+++ b/frontend/src/pages/Guide.jsx
@@ -19,6 +19,7 @@ export default function Guide() {
   const { fmtTime, fmtDate, toTZ } = useTZ();
   const scrollRef  = useRef();
   const labelsRef  = useRef();
+  const loadMoreSentinelRef = useRef(null);
   const loadingMoreRef = useRef(false);
 
   const [playlists,  setPlaylists]  = useState([]);
@@ -43,7 +44,21 @@ export default function Guide() {
 
   useEffect(() => {
     const t = setInterval(() => setNow(new Date()), 30000);
-    return () => clearInterval(t);
+  
+  useEffect(() => {
+    const root = scrollRef.current;
+    const sentinel = loadMoreSentinelRef.current;
+    if (!root || !sentinel) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some(en => en.isIntersecting)) loadNextPage();
+    }, { root, rootMargin: '300px 0px', threshold: 0.01 });
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadNextPage, channels.length, paging.total, paging.page, paging.totalPages]);
+
+  return () => clearInterval(t);
   }, []);
 
   // Load playlists list for switcher
@@ -83,9 +98,24 @@ export default function Guide() {
   }, [loading]);
 
   const viewEnd = useMemo(() => new Date(viewStart.getTime() + windowHours * 3600000), [viewStart, windowHours]);
+  const visibleWindowLabel = useMemo(() => `${fmtTime(viewStart)} → ${fmtDate(viewEnd)} ${fmtTime(viewEnd)}`, [viewStart, viewEnd, fmtTime, fmtDate]);
 
   function timeToX(date, base = viewStart) {
-    return ((date - base) / 3600000) * HOUR_WIDTH;
+  
+  useEffect(() => {
+    const root = scrollRef.current;
+    const sentinel = loadMoreSentinelRef.current;
+    if (!root || !sentinel) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some(en => en.isIntersecting)) loadNextPage();
+    }, { root, rootMargin: '300px 0px', threshold: 0.01 });
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadNextPage, channels.length, paging.total, paging.page, paging.totalPages]);
+
+  return ((date - base) / 3600000) * HOUR_WIDTH;
   }
 
   // Time slots every 30 min
@@ -140,16 +170,30 @@ export default function Guide() {
     finally { setSavingTs(false); }
   };
 
-  const syncScroll = (e) => {
-    if (labelsRef.current) labelsRef.current.scrollTop = e.currentTarget.scrollTop;
-    const el = e.currentTarget;
-    const nearBottom = (el.scrollTop + el.clientHeight) >= (el.scrollHeight - 300);
+  const loadNextPage = useCallback(() => {
     const hasMore = channels.length < paging.total;
     const nextPage = paging.page + 1;
-    if (nearBottom && hasMore && nextPage <= paging.totalPages && !loadingMoreRef.current && !loading) {
-      load(id, nextPage, true);
-    }
+    if (!hasMore || nextPage > paging.totalPages || loading || loadingMoreRef.current) return;
+    load(id, nextPage, true);
+  }, [channels.length, paging.total, paging.page, paging.totalPages, loading, id, load]);
+
+  const syncScroll = (e) => {
+    if (labelsRef.current) labelsRef.current.scrollTop = e.currentTarget.scrollTop;
   };
+
+
+  useEffect(() => {
+    const root = scrollRef.current;
+    const sentinel = loadMoreSentinelRef.current;
+    if (!root || !sentinel) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some(en => en.isIntersecting)) loadNextPage();
+    }, { root, rootMargin: '300px 0px', threshold: 0.01 });
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadNextPage, channels.length, paging.total, paging.page, paging.totalPages]);
 
   return (
     <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', background: 'var(--bg)' }}>
@@ -199,11 +243,11 @@ export default function Guide() {
           style={{ width: 80, fontSize: 12, padding: '4px 8px' }}>
           {[25,50,100,200].map(sz => <option key={sz} value={sz}>{sz}</option>)}
         </select>
-        <button className="btn btn-ghost btn-sm" disabled={loading || loadingMore || paging.page >= paging.totalPages} onClick={() => load(id, paging.page + 1, true)}>Load more</button>
+        <button className="btn btn-ghost btn-sm" disabled={loading || loadingMore || paging.page >= paging.totalPages} onClick={loadNextPage}>Load more</button>
         {loadingMore && <span className="text-muted text-sm">Loading more…</span>}
 
-        <span className="text-muted text-sm">Showing {windowHours}h window</span>
-        <select className="input" value={windowHours} onChange={e => { setWindowHours(Number(e.target.value)); }} style={{ width: 90, fontSize: 12, padding: "4px 8px" }}><option value={12}>12h</option><option value={24}>24h</option></select>
+        <span className="text-muted text-sm">Showing {windowHours}h window: {visibleWindowLabel}</span>
+        <select className="input" value={windowHours} onChange={e => { setWindowHours(Number(e.target.value)); if (scrollRef.current) scrollRef.current.scrollLeft = 0; }} style={{ width: 90, fontSize: 12, padding: "4px 8px" }}><option value={12}>12h</option><option value={24}>24h</option></select>
         <ThemeToggle />
         <button className="btn btn-ghost btn-sm" onClick={() => nav('/settings')}><Settings size={13}/></button>
           <HeaderButtons />
@@ -235,7 +279,7 @@ export default function Guide() {
           {/* Fixed channel labels */}
           <div style={{ width: LABEL_WIDTH, flexShrink: 0, borderRight: '1px solid var(--border2)', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
             <div style={{ height: 40, borderBottom: '1px solid var(--border2)', flexShrink: 0, background: 'var(--surface)' }} />
-            <div ref={labelsRef} style={{ flex: 1, overflowY: 'hidden', height: contentHeight - 40 }}>
+            <div ref={labelsRef} style={{ flex: 1, overflowY: 'hidden' }}>
               {channels.map(ch => (
                 <div key={ch.id} style={{ height: ROW_HEIGHT, display: 'flex', alignItems: 'center', gap: 8, padding: '0 10px', borderBottom: '1px solid var(--border2)', flexShrink: 0 }}>
                   {ch.tvg_logo
@@ -271,7 +315,21 @@ export default function Guide() {
 
                 {timeSlots.map((t, i) => {
                   const isDayBoundary = t.getHours() === 0 && t.getMinutes() === 0;
-                  return (
+                
+  useEffect(() => {
+    const root = scrollRef.current;
+    const sentinel = loadMoreSentinelRef.current;
+    if (!root || !sentinel) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some(en => en.isIntersecting)) loadNextPage();
+    }, { root, rootMargin: '300px 0px', threshold: 0.01 });
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadNextPage, channels.length, paging.total, paging.page, paging.totalPages]);
+
+  return (
                     <div key={i} style={{ position: 'absolute', left: timeToX(t) }}>
                       <div style={{ paddingLeft: 6, paddingTop: 6, fontSize: 11, color: isDayBoundary ? 'var(--accent)' : 'var(--muted)', fontWeight: isDayBoundary ? 700 : 400, whiteSpace: 'nowrap' }}>
                         {fmtTime(t)}
@@ -296,6 +354,7 @@ export default function Guide() {
                   search={search}
                   onSelect={prog => setSelected({ ...prog, ch })} />
               ))}
+              <div ref={loadMoreSentinelRef} style={{ position: 'absolute', left: 0, right: 0, top: contentHeight - 2, height: 2, pointerEvents: 'none' }} />
             </div>
           </div>
         </div>
@@ -365,6 +424,20 @@ function ChannelRow({ ch, timeToX, totalW, now, viewStart, viewEnd, fmtTime, onS
   const progs = ch.programmes || [];
   const ts    = ch.timeshift || 0;
 
+
+  useEffect(() => {
+    const root = scrollRef.current;
+    const sentinel = loadMoreSentinelRef.current;
+    if (!root || !sentinel) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some(en => en.isIntersecting)) loadNextPage();
+    }, { root, rootMargin: '300px 0px', threshold: 0.01 });
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadNextPage, channels.length, paging.total, paging.page, paging.totalPages]);
+
   return (
     <div style={{ height: ROW_HEIGHT, position: 'relative', borderBottom: '1px solid var(--border2)' }}>
       {progs.map((p, i) => {
@@ -382,7 +455,21 @@ function ChannelRow({ ch, timeToX, totalW, now, viewStart, viewEnd, fmtTime, onS
         const pct      = isNow ? Math.min(100, ((now - start) / (stop - start)) * 100) : 0;
         const isMatch  = search && p.title?.toLowerCase().includes(search.toLowerCase());
 
-        return (
+      
+  useEffect(() => {
+    const root = scrollRef.current;
+    const sentinel = loadMoreSentinelRef.current;
+    if (!root || !sentinel) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some(en => en.isIntersecting)) loadNextPage();
+    }, { root, rootMargin: '300px 0px', threshold: 0.01 });
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadNextPage, channels.length, paging.total, paging.page, paging.totalPages]);
+
+  return (
           <div key={i} onClick={() => onSelect({ ...p, start, stop })}
             style={{
               position: 'absolute', left: x + 1, width: w - 2, top: 4, bottom: 4,

--- a/frontend/src/pages/Guide.jsx
+++ b/frontend/src/pages/Guide.jsx
@@ -11,7 +11,6 @@ const HOUR_WIDTH  = 260;
 const ROW_HEIGHT  = 54;
 const LABEL_WIDTH = 190;
 const DEFAULT_WINDOW_HOURS = 24;
-const GUIDE_VIEW_HOURS = 6;
 
 export default function Guide() {
   const { id }    = useParams();
@@ -20,6 +19,7 @@ export default function Guide() {
   const { fmtTime, fmtDate, toTZ } = useTZ();
   const scrollRef  = useRef();
   const labelsRef  = useRef();
+  const loadingMoreRef = useRef(false);
 
   const [playlists,  setPlaylists]  = useState([]);
   const [playlist,   setPlaylist]   = useState(null);
@@ -30,6 +30,7 @@ export default function Guide() {
   const [search,     setSearch]     = useState('');
   const [windowHours,setWindowHours]= useState(DEFAULT_WINDOW_HOURS);
   const [loading,    setLoading]    = useState(true);
+  const [loadingMore,setLoadingMore]= useState(false);
   const [selected,   setSelected]   = useState(null);
   const [now,        setNow]        = useState(new Date());
   const [tsEdit,     setTsEdit]     = useState(null);   // { channelId, current }
@@ -51,7 +52,8 @@ export default function Guide() {
   }, []);
 
   const load = useCallback(async (playlistId, targetPage = 1, append = false) => {
-    setLoading(true);
+    if (append) { loadingMoreRef.current = true; setLoadingMore(true); }
+    else setLoading(true);
     try {
       const start = viewStart.toISOString();
       const end = new Date(viewStart.getTime() + windowHours * 3600000).toISOString();
@@ -64,7 +66,7 @@ export default function Guide() {
       setChannelsData(prev => append ? [...prev, ...(guideData.channels || [])] : (guideData.channels || []));
       setPaging(p => ({ ...p, total: guideData.total || 0, totalPages: guideData.total_pages || 1, page: guideData.page || targetPage }));
     } catch (e) { toast(e.message, 'error'); }
-    finally { setLoading(false); }
+    finally { if (append) { loadingMoreRef.current = false; setLoadingMore(false); } else setLoading(false); }
   }, [paging.pageSize, groupFilter, search, viewStart, windowHours, toast]);
 
   useEffect(() => { setPaging(p => ({ ...p, page: 1 })); load(id, 1, false); }, [id, groupFilter, search, viewStart, windowHours, paging.pageSize]);
@@ -80,7 +82,7 @@ export default function Guide() {
     }
   }, [loading]);
 
-  const viewEnd = useMemo(() => new Date(viewStart.getTime() + GUIDE_VIEW_HOURS * 3600000), [viewStart]);
+  const viewEnd = useMemo(() => new Date(viewStart.getTime() + windowHours * 3600000), [viewStart, windowHours]);
 
   function timeToX(date, base = viewStart) {
     return ((date - base) / 3600000) * HOUR_WIDTH;
@@ -105,7 +107,7 @@ export default function Guide() {
   }, [viewStart, viewEnd]);
 
   const nowX   = timeToX(now);
-  const totalW = GUIDE_VIEW_HOURS * HOUR_WIDTH;
+  const totalW = windowHours * HOUR_WIDTH;
 
   const shiftView   = (h) => setViewStart(v => new Date(v.getTime() + h * 3600000));
   const jumpToDay   = (offset) => {
@@ -139,6 +141,12 @@ export default function Guide() {
 
   const syncScroll = (e) => {
     if (labelsRef.current) labelsRef.current.scrollTop = e.currentTarget.scrollTop;
+    const el = e.currentTarget;
+    const nearBottom = (el.scrollHeight - el.scrollTop - el.clientHeight) < 240;
+    const hasMore = channels.length < paging.total;
+    if (nearBottom && hasMore && !loadingMoreRef.current && !loading) {
+      load(id, paging.page + 1, true);
+    }
   };
 
   return (
@@ -184,11 +192,13 @@ export default function Guide() {
         <button className="btn btn-ghost btn-icon btn-sm" onClick={() => shiftView(1)}><ChevronRight size={14}/></button>
 
         <span className="text-muted text-sm">Showing {channels.length === 0 ? 0 : 1}-{channels.length} of {paging.total.toLocaleString()}</span>
+        <label className="text-muted text-sm">Batch size</label>
         <select className="input" title="Batch size" value={paging.pageSize} onChange={e => setPaging(p => ({ ...p, pageSize: Number(e.target.value) }))}
           style={{ width: 80, fontSize: 12, padding: '4px 8px' }}>
           {[25,50,100,200].map(sz => <option key={sz} value={sz}>{sz}</option>)}
         </select>
-        <button className="btn btn-ghost btn-sm" disabled={loading || paging.page >= paging.totalPages} onClick={() => load(id, paging.page + 1, true)}>Load more</button>
+        <button className="btn btn-ghost btn-sm" disabled={loading || loadingMore || paging.page >= paging.totalPages} onClick={() => load(id, paging.page + 1, true)}>Load more</button>
+        {loadingMore && <span className="text-muted text-sm">Loading more…</span>}
 
         <select className="input" value={windowHours} onChange={e => { setWindowHours(Number(e.target.value)); }} style={{ width: 90, fontSize: 12, padding: "4px 8px" }}><option value={12}>12h</option><option value={24}>24h</option></select>
         <ThemeToggle />

--- a/frontend/src/pages/Guide.jsx
+++ b/frontend/src/pages/Guide.jsx
@@ -44,21 +44,7 @@ export default function Guide() {
 
   useEffect(() => {
     const t = setInterval(() => setNow(new Date()), 30000);
-  
-  useEffect(() => {
-    const root = scrollRef.current;
-    const sentinel = loadMoreSentinelRef.current;
-    if (!root || !sentinel) return;
-
-    const observer = new IntersectionObserver((entries) => {
-      if (entries.some(en => en.isIntersecting)) loadNextPage();
-    }, { root, rootMargin: '300px 0px', threshold: 0.01 });
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [loadNextPage, channels.length, paging.total, paging.page, paging.totalPages]);
-
-  return () => clearInterval(t);
+    return () => clearInterval(t);
   }, []);
 
   // Load playlists list for switcher
@@ -98,24 +84,13 @@ export default function Guide() {
   }, [loading]);
 
   const viewEnd = useMemo(() => new Date(viewStart.getTime() + windowHours * 3600000), [viewStart, windowHours]);
-  const visibleWindowLabel = useMemo(() => `${fmtTime(viewStart)} → ${fmtDate(viewEnd)} ${fmtTime(viewEnd)}`, [viewStart, viewEnd, fmtTime, fmtDate]);
+  const visibleWindowLabel = useMemo(
+    () => `${fmtTime(viewStart)} → ${fmtDate(viewEnd)} ${fmtTime(viewEnd)}`,
+    [viewStart, viewEnd, fmtTime, fmtDate]
+  );
 
   function timeToX(date, base = viewStart) {
-  
-  useEffect(() => {
-    const root = scrollRef.current;
-    const sentinel = loadMoreSentinelRef.current;
-    if (!root || !sentinel) return;
-
-    const observer = new IntersectionObserver((entries) => {
-      if (entries.some(en => en.isIntersecting)) loadNextPage();
-    }, { root, rootMargin: '300px 0px', threshold: 0.01 });
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [loadNextPage, channels.length, paging.total, paging.page, paging.totalPages]);
-
-  return ((date - base) / 3600000) * HOUR_WIDTH;
+    return ((date - base) / 3600000) * HOUR_WIDTH;
   }
 
   // Time slots every 30 min
@@ -181,19 +156,21 @@ export default function Guide() {
     if (labelsRef.current) labelsRef.current.scrollTop = e.currentTarget.scrollTop;
   };
 
-
   useEffect(() => {
     const root = scrollRef.current;
     const sentinel = loadMoreSentinelRef.current;
     if (!root || !sentinel) return;
 
-    const observer = new IntersectionObserver((entries) => {
-      if (entries.some(en => en.isIntersecting)) loadNextPage();
-    }, { root, rootMargin: '300px 0px', threshold: 0.01 });
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some(en => en.isIntersecting)) loadNextPage();
+      },
+      { root, rootMargin: '300px 0px', threshold: 0.01 }
+    );
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [loadNextPage, channels.length, paging.total, paging.page, paging.totalPages]);
+  }, [loadNextPage, channels.length]);
 
   return (
     <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', background: 'var(--bg)' }}>
@@ -315,21 +292,7 @@ export default function Guide() {
 
                 {timeSlots.map((t, i) => {
                   const isDayBoundary = t.getHours() === 0 && t.getMinutes() === 0;
-                
-  useEffect(() => {
-    const root = scrollRef.current;
-    const sentinel = loadMoreSentinelRef.current;
-    if (!root || !sentinel) return;
-
-    const observer = new IntersectionObserver((entries) => {
-      if (entries.some(en => en.isIntersecting)) loadNextPage();
-    }, { root, rootMargin: '300px 0px', threshold: 0.01 });
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [loadNextPage, channels.length, paging.total, paging.page, paging.totalPages]);
-
-  return (
+                  return (
                     <div key={i} style={{ position: 'absolute', left: timeToX(t) }}>
                       <div style={{ paddingLeft: 6, paddingTop: 6, fontSize: 11, color: isDayBoundary ? 'var(--accent)' : 'var(--muted)', fontWeight: isDayBoundary ? 700 : 400, whiteSpace: 'nowrap' }}>
                         {fmtTime(t)}
@@ -424,20 +387,6 @@ function ChannelRow({ ch, timeToX, totalW, now, viewStart, viewEnd, fmtTime, onS
   const progs = ch.programmes || [];
   const ts    = ch.timeshift || 0;
 
-
-  useEffect(() => {
-    const root = scrollRef.current;
-    const sentinel = loadMoreSentinelRef.current;
-    if (!root || !sentinel) return;
-
-    const observer = new IntersectionObserver((entries) => {
-      if (entries.some(en => en.isIntersecting)) loadNextPage();
-    }, { root, rootMargin: '300px 0px', threshold: 0.01 });
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [loadNextPage, channels.length, paging.total, paging.page, paging.totalPages]);
-
   return (
     <div style={{ height: ROW_HEIGHT, position: 'relative', borderBottom: '1px solid var(--border2)' }}>
       {progs.map((p, i) => {
@@ -455,21 +404,7 @@ function ChannelRow({ ch, timeToX, totalW, now, viewStart, viewEnd, fmtTime, onS
         const pct      = isNow ? Math.min(100, ((now - start) / (stop - start)) * 100) : 0;
         const isMatch  = search && p.title?.toLowerCase().includes(search.toLowerCase());
 
-      
-  useEffect(() => {
-    const root = scrollRef.current;
-    const sentinel = loadMoreSentinelRef.current;
-    if (!root || !sentinel) return;
-
-    const observer = new IntersectionObserver((entries) => {
-      if (entries.some(en => en.isIntersecting)) loadNextPage();
-    }, { root, rootMargin: '300px 0px', threshold: 0.01 });
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [loadNextPage, channels.length, paging.total, paging.page, paging.totalPages]);
-
-  return (
+        return (
           <div key={i} onClick={() => onSelect({ ...p, start, stop })}
             style={{
               position: 'absolute', left: x + 1, width: w - 2, top: 4, bottom: 4,


### PR DESCRIPTION
### Motivation
- Large playlists and XMLTV datasets caused the Guide UI to freeze or become sluggish by sending thousands of programme rows to the frontend, so the Guide must load channels and programmes server-side and only send visible data.
- Provide flexible search/group filtering and a time-window so the frontend can request only the required programme window instead of the whole EPG.
- Add lightweight paging UI controls so users can browse very large playlists without rendering thousands of rows at once.

### Description
- Implemented a paginated Guide API at `GET /api/guide/:playlist_id` supporting `page`, `page_size`, `group`, `q`, `start`, and `end`, with default `page_size` 50 and allowed sizes `25/50/100/200` and a default time window (~now → +24h). 
- Backend now selects channels per-page, collects only the required `epg_id`s, reads programme entries only for that time window and page channels, caches page responses, and emits performance-aware logs and heavy-load warnings via the existing logger without exposing sensitive tokens/URLs.
- Frontend API (`frontend/src/api.js`) updated to call the new endpoint shape and the Guide UI (`frontend/src/pages/Guide.jsx`) was updated to use server-side paging and filtering, show a loading state and a range text (`Showing X–Y of Z`), include a Rows dropdown (25/50/100/200), Prev/Next buttons, and a 12h/24h time-window selector, while resetting page to 1 on page-size/search/group/window changes.
- Guide behaviour for small playlists and playlist export/serve generation are unchanged because pagination affects only the Guide API responses, not playlist or XMLTV generation.

### Testing
- Built the frontend with `npm --prefix frontend run build` and the build completed successfully.
- Performed a backend syntax/check with `node -c backend/src/routes/guide.js` which passed without syntax errors.
- Note: attempting to rebase/fetch the latest remote `main` failed because the environment has no configured `origin` remote, so the change was applied on the available local branch state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e716b64a883318d8b21186da8f20f)