### PR TITLE
Follow-up: switch README hero + favicon to branding package assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-<h1 align="center">Stationarr</h1>
+<p align="center">
+  <img src="frontend/branding/svg/stationarr-vertical.svg" alt="Stationarr" width="260">
+</p>
 
 <p align="center">
-  <strong>Self-hosted IPTV playlist and EPG manager</strong>
+  IPTV playlist editor, EPG matcher, and self-hosted companion for the *arr ecosystem.
 </p>
 
 <p align="center">
@@ -21,6 +23,25 @@ Stationarr is a playlist and EPG management tool only. It does **not** provide, 
 See [DISCLAIMER.md](DISCLAIMER.md) before using or contributing to this project.
 
 ---
+
+## Branding assets
+
+Stationarr branding assets are available in:
+
+```text
+frontend/branding/
+```
+
+The main downloadable app logo is:
+
+```text
+frontend/branding/logo.png
+```
+
+The branding package also includes additional PNG sizes, SVG versions, horizontal and vertical logo variants, brand tokens, and brand sheet assets.
+
+---
+
 
 ## Screenshots
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Stationarr</title>
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/svg/stationarr-icon.svg" />
+    <link rel="icon" type="image/png" href="/logo-32.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  publicDir: 'branding',
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
### Motivation
- Replace the README hero with the vertical full-name Stationarr logo from the branding package instead of `logo.png` so the docs display the branded vertical mark. 
- Keep `logo.png` available as the primary downloadable app logo and document the branding package location for contributors. 
- Update the app favicon references to point at real branding assets and ensure the Vite build serves those static files.

### Description
- Replaced the README header with an image tag referencing `frontend/branding/svg/stationarr-vertical.svg` and updated the short tagline block.  
- Added a `## Branding assets` section to `README.md` documenting `frontend/branding/` and `frontend/branding/logo.png` as the main downloadable logo.  
- Updated `frontend/index.html` to use the branding assets with SVG primary and PNG fallback by linking `/svg/stationarr-icon.svg` and `/logo-32.png`.  
- Set `publicDir: 'branding'` in `frontend/vite.config.js` so the `branding` folder is served as Vite public assets at build/runtime.

### Testing
- Ran `npm --prefix frontend run build` (Vite build) and it completed successfully.  
- Verified that `frontend/index.html` favicon references point to existing files in the branding package.  
- Verified README now references the vertical full-name logo and still documents `logo.png` as the downloadable app logo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f38133a888331b98488370761d5e8)