### PR TITLE
Use Xtream `player_api.php` for Provider Login import/refresh (fixes #69)

### DIFF
--- a/backend/src/routes/playlists.js
+++ b/backend/src/routes/playlists.js
@@ -6,6 +6,7 @@ const { parseM3U } = require('../utils/m3u');
 const { buildHttpStatusError, getPlaylistFetchErrorMessage } = require('../utils/http-errors');
 const fetch   = require('node-fetch');
 const logger = require('../logger');
+const { buildPlayerApiUrl, fetchXtreamChannels } = require('../utils/provider-login');
 
 router.use(requireAuth);
 
@@ -14,10 +15,9 @@ function genXtreamCreds() {
 }
 
 function buildSourceUrl(body) {
-  // Build M3U URL from provider credentials if source_type is 'xtream'
+  // Provider login uses Xtream player_api endpoint
   if (body.source_type === 'xtream' && body.source_server) {
-    const base = body.source_server.replace(/\/$/, '');
-    return `${base}/get.php?username=${encodeURIComponent(body.source_username || '')}&password=${encodeURIComponent(body.source_password || '')}&type=m3u_plus&output=ts`;
+    return buildPlayerApiUrl(body.source_server, body.source_username, body.source_password);
   }
   return body.source_url || null;
 }
@@ -121,8 +121,26 @@ router.post('/:id/import', async (req, res) => {
     // Build URL from request body (may include provider credentials)
     let url = req.body.url;
     if (req.body.source_type === 'xtream' && req.body.source_server) {
-      const base = req.body.source_server.replace(/\/$/, '');
-      url = `${base}/get.php?username=${encodeURIComponent(req.body.source_username || '')}&password=${encodeURIComponent(req.body.source_password || '')}&type=m3u_plus&output=ts`;
+      try {
+        const { authUrl, channels } = await fetchXtreamChannels(req.body);
+        const insert = db.prepare(`
+          INSERT INTO channels (playlist_id, name, url, duration, tvg_id, tvg_name, tvg_logo, grp, epg_id, enabled, ord)
+          VALUES (@playlist_id, @name, @url, @duration, @tvg_id, @tvg_name, @tvg_logo, @grp, @epg_id, @enabled, @ord)
+        `);
+
+        db.transaction((chs) => {
+          db.prepare('DELETE FROM channels WHERE playlist_id = ?').run(pl.id);
+          chs.forEach((c, i) => insert.run({ ...c, playlist_id: pl.id, ord: i }));
+          db.prepare("UPDATE playlists SET source_url=?, source_type=?, source_server=?, source_username=?, source_password=?, updated_at=datetime('now'), last_refreshed=datetime('now') WHERE id=?")
+            .run(authUrl, 'xtream', req.body.source_server || null, req.body.source_username || null, req.body.source_password || null, pl.id);
+        })(channels);
+
+        logger.info('playlist', 'Provider login import success', { playlist_id: pl.id, imported: channels.length });
+        return res.json({ imported: channels.length, import_summary: { total_entries: channels.length, imported_live: channels.length, skipped_vod_like: 0, include_vod_like: false } });
+      } catch (e) {
+        logger.error('playlist', 'Provider login import failed', { playlist_id: pl.id, source_type: 'xtream', error: e?.message || String(e) });
+        return res.status(502).json({ error: getPlaylistFetchErrorMessage(e, 'Could not fetch provider API:') });
+      }
     }
     if (!url) return res.status(400).json({ error: 'content, url, or provider credentials required' });
 

--- a/backend/src/scheduler.js
+++ b/backend/src/scheduler.js
@@ -13,6 +13,7 @@ const { countProgrammeEntriesFromBuffer } = require('./utils/xmltv-programme-cou
 const { buildHttpStatusError, getPlaylistFetchErrorMessage } = require('./utils/http-errors');
 const logger = require('./logger');
 const { queueGuideIndex } = require('./utils/guide-indexer');
+const { fetchXtreamChannels } = require('./utils/provider-login');
 
 const DATA_DIR    = process.env.DATA_DIR || './data';
 const CHECK_EVERY = 15 * 60 * 1000; // 15 minutes
@@ -26,15 +27,24 @@ function buildM3UUrl(pl) {
 
 async function refreshPlaylist(pl) {
   const url = buildM3UUrl(pl);
-  if (!url) return;
+  if (!url && pl.source_type !== 'xtream') return;
 
   console.log(`[scheduler] Refreshing playlist "${pl.name}" (id=${pl.id})`);
   logger.info('scheduler','Playlist scheduled refresh started',{ playlist_id: pl.id, playlist_name: pl.name });
   try {
-    const r = await fetch(url, { timeout: 30000, follow: 10, compress: true });
-    if (!r.ok) throw buildHttpStatusError(r.status);
-    const text = await r.text();
-    const { channels, counts } = parseM3U(text);
+    let channels;
+    let counts;
+    if (pl.source_type === 'xtream' && pl.source_server && pl.source_username) {
+      channels = (await fetchXtreamChannels(pl)).channels;
+      counts = { importedLive: channels.length, totalEntries: channels.length, skippedVodLike: 0 };
+    } else {
+      const r = await fetch(url, { timeout: 30000, follow: 10, compress: true });
+      if (!r.ok) throw buildHttpStatusError(r.status);
+      const text = await r.text();
+      const parsed = parseM3U(text);
+      channels = parsed.channels;
+      counts = parsed.counts;
+    }
 
     const insert = db.prepare(`
       INSERT INTO channels (playlist_id, name, url, duration, tvg_id, tvg_name, tvg_logo, grp, epg_id, enabled, ord)
@@ -53,7 +63,7 @@ async function refreshPlaylist(pl) {
   } catch (e) {
     console.error(`[scheduler] Failed to refresh playlist "${pl.name}":`, getPlaylistFetchErrorMessage(e, 'Playlist fetch failed:'));
     if (e && Number(e.status) === 451) logger.warn('playlist','HTTP 451 playlist fetch warning',{ playlist_id: pl.id, playlist_name: pl.name });
-    logger.error('scheduler','Playlist scheduled refresh failure',{ playlist_id: pl.id, error: e?.message || String(e) });
+    logger.error('scheduler','Playlist scheduled refresh failure',{ playlist_id: pl.id, source_type: pl.source_type || 'url', error: e?.message || String(e) });
     if (e && e.message) {
       console.error(`[scheduler] Technical fetch error for playlist "${pl.name}":`, e.message);
     }

--- a/backend/src/utils/provider-login.js
+++ b/backend/src/utils/provider-login.js
@@ -1,0 +1,52 @@
+const fetch = require('node-fetch');
+const { buildHttpStatusError } = require('./http-errors');
+
+function normalizeBase(server) {
+  return String(server || '').trim().replace(/\/+$/, '');
+}
+
+function buildPlayerApiUrl(server, username, password, action) {
+  const base = normalizeBase(server);
+  const qs = new URLSearchParams({
+    username: username || '',
+    password: password || '',
+  });
+  if (action) qs.set('action', action);
+  return `${base}/player_api.php?${qs.toString()}`;
+}
+
+async function fetchJson(url) {
+  const r = await fetch(url, { timeout: 30000, follow: 10, compress: true });
+  if (!r.ok) throw buildHttpStatusError(r.status);
+  return r.json();
+}
+
+async function fetchXtreamChannels({ source_server, source_username, source_password }) {
+  const authUrl = buildPlayerApiUrl(source_server, source_username, source_password);
+  const auth = await fetchJson(authUrl);
+  if (!auth?.user_info?.auth || String(auth.user_info.auth) !== '1') {
+    throw new Error('Provider authentication failed. Please verify server, username, and password.');
+  }
+
+  const [categories, streams] = await Promise.all([
+    fetchJson(buildPlayerApiUrl(source_server, source_username, source_password, 'get_live_categories')),
+    fetchJson(buildPlayerApiUrl(source_server, source_username, source_password, 'get_live_streams')),
+  ]);
+
+  const catMap = new Map((Array.isArray(categories) ? categories : []).map(c => [String(c.category_id), c.category_name || 'Other']));
+  const channelRows = (Array.isArray(streams) ? streams : []).map((s, idx) => ({
+    name: s.name || s.stream_display_name || `Channel ${idx + 1}`,
+    url: s.stream_url || s.direct_source || '',
+    duration: -1,
+    tvg_id: s.epg_channel_id || '',
+    tvg_name: s.name || '',
+    tvg_logo: s.stream_icon || '',
+    grp: catMap.get(String(s.category_id)) || s.category_name || 'Other',
+    epg_id: s.epg_channel_id || '',
+    enabled: 1,
+  })).filter(ch => ch.url);
+
+  return { authUrl, channels: channelRows };
+}
+
+module.exports = { buildPlayerApiUrl, fetchXtreamChannels };

--- a/backend/src/utils/provider-login.js
+++ b/backend/src/utils/provider-login.js
@@ -15,6 +15,13 @@ function buildPlayerApiUrl(server, username, password, action) {
   return `${base}/player_api.php?${qs.toString()}`;
 }
 
+function buildXtreamLiveStreamUrl(server, username, password, streamId, extension = 'ts') {
+  const base = normalizeBase(server);
+  const safeExtension = String(extension || 'ts').replace(/^\./, '') || 'ts';
+  if (!base || !username || !password || !streamId) return '';
+  return `${base}/live/${encodeURIComponent(username)}/${encodeURIComponent(password)}/${encodeURIComponent(streamId)}.${safeExtension}`;
+}
+
 async function fetchJson(url) {
   const r = await fetch(url, { timeout: 30000, follow: 10, compress: true });
   if (!r.ok) throw buildHttpStatusError(r.status);
@@ -36,7 +43,9 @@ async function fetchXtreamChannels({ source_server, source_username, source_pass
   const catMap = new Map((Array.isArray(categories) ? categories : []).map(c => [String(c.category_id), c.category_name || 'Other']));
   const channelRows = (Array.isArray(streams) ? streams : []).map((s, idx) => ({
     name: s.name || s.stream_display_name || `Channel ${idx + 1}`,
-    url: s.stream_url || s.direct_source || '',
+    url: s.stream_url
+      || s.direct_source
+      || buildXtreamLiveStreamUrl(source_server, source_username, source_password, s.stream_id, 'ts'),
     duration: -1,
     tvg_id: s.epg_channel_id || '',
     tvg_name: s.name || '',
@@ -49,4 +58,4 @@ async function fetchXtreamChannels({ source_server, source_username, source_pass
   return { authUrl, channels: channelRows };
 }
 
-module.exports = { buildPlayerApiUrl, fetchXtreamChannels };
+module.exports = { buildPlayerApiUrl, buildXtreamLiveStreamUrl, fetchXtreamChannels };

--- a/frontend/src/components/ImportModal.jsx
+++ b/frontend/src/components/ImportModal.jsx
@@ -144,7 +144,7 @@ export default function ImportModal({ playlistId, playlistName, allPlaylists = [
                 </div>
               </div>
               <div style={{ background: 'var(--surface2)', borderRadius: 6, padding: '8px 12px', fontSize: 11, color: 'var(--muted)', wordBreak: 'break-all' }}>
-                {server ? `${server.replace(/\/$/, '')}/get.php?username=${username || '…'}&password=***&type=m3u_plus` : 'Enter server above to see URL preview'}
+                {server ? `${server.replace(/\/$/, '')}/player_api.php?username=${username || '…'}&password=***` : 'Enter server above to see URL preview'}
               </div>
               <button type="submit" className="btn btn-primary" disabled={loading} style={{ justifyContent: 'center' }}>
                 {loading ? 'Importing…' : 'Connect & import'}


### PR DESCRIPTION
### Motivation
- Provider Login was constructing `/get.php?...&type=m3u_plus` M3U URLs which returned `HTTP 884` for some providers instead of using the Xtream Codes API. 
- The intent is for Provider Login to authenticate and import streams via the Xtream API (`/player_api.php`) so providers that do not expose M3U via `/get.php` still work. 
- Scheduler auto-refresh and import flows must use the same Xtream API flow for `source_type=xtream` while preserving existing M3U URL and file upload behavior.

### Description
- Added a new backend util `backend/src/utils/provider-login.js` that builds sanitized `player_api.php` URLs and provides `fetchXtreamChannels` to authenticate and fetch `get_live_categories` + `get_live_streams` responses and map them into channel rows. 
- Updated `backend/src/routes/playlists.js` to store a `player_api.php`-style `source_url` for `source_type='xtream'` and to import provider-login playlists via `fetchXtreamChannels` (channels are saved directly from API responses and credentials are persisted for refresh). 
- Updated `backend/src/scheduler.js` so playlists with `source_type='xtream'` refresh via the Xtream API flow and M3U URL playlists continue to use the existing M3U fetch+parse flow, and added `source_type` context to refresh failure logs. 
- Updated the Provider Login UI preview in `frontend/src/components/ImportModal.jsx` to show the `player_api.php` URL format to match backend behavior. 
- Improved error handling and sanitized logging for provider-login import/refresh failures while avoiding logging raw credentials.

### Testing
- Ran backend syntax checks with `node --check backend/src/routes/playlists.js backend/src/scheduler.js backend/src/utils/provider-login.js` and they succeeded. 
- Built the frontend with `npm run build` in `frontend/` and the production build completed successfully. 
- No automated unit tests were added; the validation focused on syntax checks and a successful frontend build which both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16f15cb68083318b5888fb7b46a52c)