### PR TITLE
Fix manual refresh API and trust proxy config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ BASE_URL=http://localhost:3000
 REGISTRATION_OPEN=true
 SCRAPER_URL=http://stationarr-epg:3000
 SCRAPER_CHANNELS_PATH=/app/data/scraper/channels.xml
+TRUST_PROXY=false

--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ sudo ln -s /etc/nginx/sites-available/stationarr.conf /etc/nginx/sites-enabled/
 sudo nginx -t && sudo systemctl reload nginx
 ```
 
+When Stationarr is deployed behind a trusted reverse proxy that sends `X-Forwarded-For`, set `TRUST_PROXY=true` (or `TRUST_PROXY=1`). This trusts exactly one proxy hop for Express rate-limit/IP handling. Leave it unset or `false` for direct/non-proxy deployments.
+
 ---
 
 ## Environment variables
@@ -259,6 +261,7 @@ sudo nginx -t && sudo systemctl reload nginx
 | `DATA_DIR` | `./data` | Directory for SQLite DB and EPG cache |
 | `BASE_URL` | `http://localhost:3000` | Public base URL — used in hosted playlist links |
 | `REGISTRATION_OPEN` | `true` | Set to `false` to disable new user signups after setup |
+| `TRUST_PROXY` | `false` | Set to `true` or `1` only when Stationarr is behind one trusted reverse proxy that sends `X-Forwarded-For` |
 | `SCRAPER_URL` | `http://epg:3000` | URL of the iptv-org/epg sidecar container |
 | `SCRAPER_CHANNELS_PATH` | `/app/data/scraper/channels.xml` | Path to channels.xml shared with scraper |
 

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -8,6 +8,11 @@ const logger = require('./logger');
 
 const app  = express();
 const PORT = process.env.PORT || 3000;
+const trustProxy = String(process.env.TRUST_PROXY || '').toLowerCase();
+
+if (trustProxy === 'true' || trustProxy === '1') {
+  app.set('trust proxy', 1);
+}
 
 app.use(cors({ origin: process.env.NODE_ENV === 'production' ? false : '*' }));
 app.use(express.json({ limit: '20mb' }));

--- a/backend/src/routes/epg.js
+++ b/backend/src/routes/epg.js
@@ -10,6 +10,7 @@ const path    = require('path');
 const fs      = require('fs');
 const logger  = require('../logger');
 const { queueGuideIndex } = require('../utils/guide-indexer');
+const { redactSensitiveUrls } = require('../utils/http-errors');
 
 const DATA_DIR = process.env.DATA_DIR || './data';
 
@@ -172,8 +173,9 @@ router.post('/:id/fetch', async (req, res) => {
   } catch (e) {
     // Clean up tmp file on error
     try { require('fs').unlinkSync(tmpPath); } catch {}
-    logger.error('epg', 'Manual EPG source fetch failure', { source_id: src.id, error: e?.message || String(e) });
-    res.status(502).json({ error: 'Fetch failed: ' + e.message });
+    const safeMessage = redactSensitiveUrls(e?.message || String(e));
+    logger.error('epg', 'Manual EPG source fetch failure', { source_id: src.id, error: safeMessage });
+    res.status(502).json({ error: 'Fetch failed: ' + safeMessage });
   }
 });
 
@@ -211,6 +213,7 @@ router.delete('/:id/cache', (req, res) => {
 router.post('/:id/refresh', async (req, res) => {
   const src = db.prepare('SELECT * FROM epg_sources WHERE id=? AND user_id=?').get(req.params.id, req.user.id);
   if (!src) return res.status(404).json({ error: 'Not found' });
+  if (!src.url) return res.status(400).json({ error: 'Source has no URL to refresh from' });
   logger.info('epg', 'Manual EPG source refresh started', { source_id: src.id, source_name: src.name });
   try {
     await require('../scheduler').refreshEPGSource(src);
@@ -218,8 +221,9 @@ router.post('/:id/refresh', async (req, res) => {
     logger.info('epg', 'Manual EPG source refresh success', { source_id: src.id, channels: updated?.channel_count || 0, programmes: updated?.programme_count || 0 });
     res.json(updated);
   } catch (e) {
-    logger.error('epg', 'Manual EPG source refresh failure', { source_id: src.id, error: e?.message || String(e) });
-    res.status(502).json({ error: e.message });
+    const safeMessage = redactSensitiveUrls(e?.message || String(e));
+    logger.error('epg', 'Manual EPG source refresh failure', { source_id: src.id, error: safeMessage });
+    res.status(502).json({ error: 'EPG source refresh failed: ' + safeMessage });
   }
 });
 

--- a/backend/src/routes/playlists.js
+++ b/backend/src/routes/playlists.js
@@ -3,7 +3,7 @@ const db     = require('../db');
 const requireAuth = require('../middleware/auth');
 const { nanoid }  = require('nanoid');
 const { parseM3U } = require('../utils/m3u');
-const { buildHttpStatusError, getPlaylistFetchErrorMessage } = require('../utils/http-errors');
+const { buildHttpStatusError, getPlaylistFetchErrorMessage, redactSensitiveUrls } = require('../utils/http-errors');
 const fetch   = require('node-fetch');
 const logger = require('../logger');
 
@@ -137,8 +137,8 @@ router.post('/:id/import', async (req, res) => {
         WHERE id=?
       `).run(url, req.body.source_type || 'url', req.body.source_server || null, req.body.source_username || null, req.body.source_password || null, pl.id);
     } catch (e) {
-      if (e && Number(e.status) === 451) logger.warn('playlist','HTTP 451 playlist fetch warning',{ playlist_id: pl.id });
-      logger.error('playlist','Playlist import failed',{ playlist_id: pl.id, error: e?.message || String(e) });
+      if (e && Number(e.httpStatus) === 451) logger.warn('playlist','HTTP 451 playlist fetch warning',{ playlist_id: pl.id });
+      logger.error('playlist','Playlist import failed',{ playlist_id: pl.id, error: redactSensitiveUrls(e?.message || String(e)) });
       return res.status(502).json({ error: getPlaylistFetchErrorMessage(e, 'Could not fetch URL:') });
     }
   }
@@ -173,6 +173,9 @@ router.post('/:id/import', async (req, res) => {
 router.post('/:id/refresh', async (req, res) => {
   const pl = db.prepare('SELECT * FROM playlists WHERE id = ? AND user_id = ?').get(req.params.id, req.user.id);
   if (!pl) return res.status(404).json({ error: 'Not found' });
+  const hasRefreshSource = Boolean(pl.source_url || (pl.source_type === 'xtream' && pl.source_server && pl.source_username && pl.source_password));
+  if (!hasRefreshSource) return res.status(400).json({ error: 'Playlist has no saved source URL or complete provider credentials to refresh from' });
+
   logger.info('playlist','Playlist manual refresh started',{ playlist_id: pl.id, playlist_name: pl.name });
   try {
     await require('../scheduler').refreshPlaylist(pl);
@@ -181,8 +184,8 @@ router.post('/:id/refresh', async (req, res) => {
     logger.info('playlist','Playlist scheduled refresh success',{ playlist_id: pl.id, channel_count: count });
     res.json({ ok: true, channel_count: count, last_refreshed: updated.last_refreshed });
   } catch (e) {
-    logger.error('playlist','Playlist manual refresh failure',{ playlist_id: pl.id, error: e?.message || String(e) });
-    res.status(502).json({ error: e.message });
+    logger.error('playlist','Playlist manual refresh failure',{ playlist_id: pl.id, error: redactSensitiveUrls(e?.message || String(e)) });
+    res.status(502).json({ error: getPlaylistFetchErrorMessage(e, 'Playlist refresh failed:') });
   }
 });
 

--- a/backend/src/scheduler.js
+++ b/backend/src/scheduler.js
@@ -10,7 +10,7 @@ const { parseM3U }  = require('./utils/m3u');
 const { parseXMLTVBuffer } = require('./utils/xmltv');
 const { saveEPGCache } = require('./utils/xmltv-merge');
 const { countProgrammeEntriesFromBuffer } = require('./utils/xmltv-programme-count');
-const { buildHttpStatusError, getPlaylistFetchErrorMessage } = require('./utils/http-errors');
+const { buildHttpStatusError, getPlaylistFetchErrorMessage, redactSensitiveUrls } = require('./utils/http-errors');
 const logger = require('./logger');
 const { queueGuideIndex } = require('./utils/guide-indexer');
 
@@ -51,12 +51,14 @@ async function refreshPlaylist(pl) {
     console.log(`[scheduler] Playlist "${pl.name}" refreshed — ${counts.importedLive}/${counts.totalEntries} live channels imported (${counts.skippedVodLike} VOD-like entries skipped)`);
     logger.info('scheduler','Playlist scheduled refresh success',{ playlist_id: pl.id, imported_live: counts.importedLive, total_entries: counts.totalEntries });
   } catch (e) {
+    const safeMessage = redactSensitiveUrls(e?.message || String(e));
     console.error(`[scheduler] Failed to refresh playlist "${pl.name}":`, getPlaylistFetchErrorMessage(e, 'Playlist fetch failed:'));
-    if (e && Number(e.status) === 451) logger.warn('playlist','HTTP 451 playlist fetch warning',{ playlist_id: pl.id, playlist_name: pl.name });
-    logger.error('scheduler','Playlist scheduled refresh failure',{ playlist_id: pl.id, error: e?.message || String(e) });
+    if (e && Number(e.httpStatus) === 451) logger.warn('playlist','HTTP 451 playlist fetch warning',{ playlist_id: pl.id, playlist_name: pl.name });
+    logger.error('scheduler','Playlist scheduled refresh failure',{ playlist_id: pl.id, error: safeMessage });
     if (e && e.message) {
-      console.error(`[scheduler] Technical fetch error for playlist "${pl.name}":`, e.message);
+      console.error(`[scheduler] Technical fetch error for playlist "${pl.name}":`, safeMessage);
     }
+    throw e;
   }
 }
 
@@ -89,8 +91,10 @@ async function refreshEPGSource(src) {
     console.log(`[scheduler] EPG source "${src.name}" refreshed — ${channels.length} channels, ${programmeCount} programmes, ${(size/1024/1024).toFixed(1)} MB`);
     logger.info('epg','EPG source fetch success',{ source_id: src.id, channels: channels.length, programmes: programmeCount });
   } catch (e) {
-    console.error(`[scheduler] Failed to refresh EPG source "${src.name}":`, e.message);
-    logger.error('epg','EPG source fetch failure',{ source_id: src.id, error: e?.message || String(e) });
+    const safeMessage = redactSensitiveUrls(e?.message || String(e));
+    console.error(`[scheduler] Failed to refresh EPG source "${src.name}":`, safeMessage);
+    logger.error('epg','EPG source fetch failure',{ source_id: src.id, error: safeMessage });
+    throw e;
   }
 }
 
@@ -109,7 +113,11 @@ async function runCheck() {
 
   for (const pl of playlists) {
     if (isDue(pl.last_refreshed, pl.refresh_interval || 24)) {
-      await refreshPlaylist(pl);
+      try {
+        await refreshPlaylist(pl);
+      } catch {
+        // refreshPlaylist already logs a sanitized failure; keep scheduler loop alive.
+      }
     }
   }
 
@@ -120,7 +128,11 @@ async function runCheck() {
 
   for (const src of sources) {
     if (isDue(src.last_refreshed, src.refresh_interval || 24)) {
-      await refreshEPGSource(src);
+      try {
+        await refreshEPGSource(src);
+      } catch {
+        // refreshEPGSource already logs a sanitized failure; keep scheduler loop alive.
+      }
     }
   }
 }

--- a/backend/src/utils/http-errors.js
+++ b/backend/src/utils/http-errors.js
@@ -7,16 +7,21 @@ function buildHttpStatusError(status) {
   return err;
 }
 
+function redactSensitiveUrls(message) {
+  return String(message || 'Unknown error').replace(/https?:\/\/[^\s)]+/gi, '[redacted URL]');
+}
+
 function getPlaylistFetchErrorMessage(err, prefix) {
   const basePrefix = prefix || 'Could not fetch URL:';
   if (err && err.httpStatus === 451) {
     return `${basePrefix} ${HTTP_451_MESSAGE}`;
   }
-  return `${basePrefix} ${(err && err.message) || 'Unknown error'}`;
+  return `${basePrefix} ${redactSensitiveUrls((err && err.message) || 'Unknown error')}`;
 }
 
 module.exports = {
   HTTP_451_MESSAGE,
   buildHttpStatusError,
   getPlaylistFetchErrorMessage,
+  redactSensitiveUrls,
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - DATA_DIR=/app/data
       - BASE_URL=${BASE_URL:-http://localhost:3000}
       - REGISTRATION_OPEN=${REGISTRATION_OPEN:-true}
+      - TRUST_PROXY=${TRUST_PROXY:-false}
       - SCRAPER_URL=http://stationarr-epg:3000
       # Must stay under /app/data for Stationarr; do not point to /epg/public
       - SCRAPER_CHANNELS_PATH=/app/data/scraper/channels.xml

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -79,6 +79,7 @@ export const playlists = {
   remove:      (id)       => del(`/playlists/${id}`),
   regenXtream: (id)       => post(`/playlists/${id}/regen-xtream`),
   import: (id, body) => post(`/playlists/${id}/import`, body),
+  refresh: (id)       => post(`/playlists/${id}/refresh`),
 };
 
 export const channels = {


### PR DESCRIPTION
### Motivation
- The Dashboard and EPG panels called a `refresh()` helper but the frontend API client lacked a `playlists.refresh` export which caused `refresh is not a function` errors. 
- Manual refresh endpoints returned raw error messages and sometimes attempted refreshes without an available source, exposing provider URLs/credentials in logs. 
- Deployments behind a reverse proxy produced `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` warnings because Express `trust proxy` handling was not configurable.

### Description
- Added `playlists.refresh(id)` to `frontend/src/api.js` so UI `Refresh now` buttons call `POST /api/playlists/:id/refresh`. 
- Added URL redaction helper `redactSensitiveUrls` in `backend/src/utils/http-errors.js` and used it to sanitize logged and returned error messages from playlist/EPG fetch/refresh code. 
- Validated manual refresh preconditions in backend routes by returning `400` when a playlist or EPG source has no saved URL/complete provider credentials, and returned sanitized, user-friendly errors on failure in `backend/src/routes/playlists.js` and `backend/src/routes/epg.js`. 
- Updated `backend/src/scheduler.js` to rethrow errors for manual callers while wrapping scheduled loop calls in `try/catch` so one failure does not stop the scheduler. 
- Added opt-in `TRUST_PROXY` env support in `backend/src/index.js` that sets `app.set('trust proxy', 1)` when `TRUST_PROXY=true|1`, and documented the variable in `README.md`, `.env.example`, and `docker-compose.yml` without changing default behaviour. 

### Testing
- Ran backend syntax checks (`node --check` over `backend/src/*.js`) and built the frontend with `npm --prefix frontend run build`, both of which succeeded. 
- Verified code search shows frontend `.refresh(` usages map to API client functions and that `refresh:` exists in `frontend/src/api.js`. 
- Started the backend with `TRUST_PROXY=true` and exercised `GET /api/health` with an `X-Forwarded-For` header and confirmed logs did not contain `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` or related validation errors. 
- Started the backend with default `TRUST_PROXY` (unset/false) and confirmed normal startup and `GET /api/health` still works.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f13470a308331b474e6f60944c969)