### PR TITLE
Fix Xtream Provider Login EPG import

### DIFF
--- a/backend/src/routes/playlists.js
+++ b/backend/src/routes/playlists.js
@@ -7,6 +7,7 @@ const { buildHttpStatusError, getPlaylistFetchErrorMessage, redactSensitiveUrls 
 const fetch   = require('node-fetch');
 const logger = require('../logger');
 const { buildPlayerApiUrl, fetchXtreamChannels } = require('../utils/provider-login');
+const { importXtreamEPGForPlaylist, sanitizeXtreamEPGError } = require('../utils/xtream-epg');
 
 router.use(requireAuth);
 
@@ -135,8 +136,24 @@ router.post('/:id/import', async (req, res) => {
             .run(authUrl, 'xtream', req.body.source_server || null, req.body.source_username || null, req.body.source_password || null, pl.id);
         })(channels);
 
-        logger.info('playlist', 'Provider login import success', { playlist_id: pl.id, imported: channels.length });
-        return res.json({ imported: channels.length, import_summary: { total_entries: channels.length, imported_live: channels.length, skipped_vod_like: 0, include_vod_like: false } });
+        let epg_warning = null;
+        let epg_import = null;
+        try {
+          const updatedPlaylist = db.prepare('SELECT * FROM playlists WHERE id = ?').get(pl.id);
+          epg_import = await importXtreamEPGForPlaylist(updatedPlaylist);
+          logger.info('playlist', 'Provider login EPG import success', { playlist_id: pl.id, source_id: epg_import.source_id, channels: epg_import.loaded, programmes: epg_import.programme_count });
+        } catch (epgError) {
+          epg_warning = 'Provider playlist imported, but the provider EPG could not be imported.';
+          logger.warn('playlist', 'Provider login EPG import failed', { playlist_id: pl.id, error: sanitizeXtreamEPGError(epgError) });
+        }
+
+        logger.info('playlist', 'Provider login import success', { playlist_id: pl.id, imported: channels.length, epg_imported: !!epg_import });
+        return res.json({
+          imported: channels.length,
+          import_summary: { total_entries: channels.length, imported_live: channels.length, skipped_vod_like: 0, include_vod_like: false },
+          epg_import,
+          epg_warning,
+        });
       } catch (e) {
         logger.error('playlist', 'Provider login import failed', { playlist_id: pl.id, source_type: 'xtream', error: e?.message || String(e) });
         return res.status(502).json({ error: getPlaylistFetchErrorMessage(e, 'Could not fetch provider API:') });

--- a/backend/src/scheduler.js
+++ b/backend/src/scheduler.js
@@ -14,6 +14,7 @@ const { buildHttpStatusError, getPlaylistFetchErrorMessage, redactSensitiveUrls 
 const logger = require('./logger');
 const { queueGuideIndex } = require('./utils/guide-indexer');
 const { fetchXtreamChannels } = require('./utils/provider-login');
+const { importXtreamEPGForPlaylist, sanitizeXtreamEPGError } = require('./utils/xtream-epg');
 
 const DATA_DIR    = process.env.DATA_DIR || './data';
 const CHECK_EVERY = 15 * 60 * 1000; // 15 minutes
@@ -63,6 +64,23 @@ async function refreshPlaylist(pl) {
       channels.forEach((c, i) => insert.run({ ...c, playlist_id: pl.id, ord: i }));
       db.prepare("UPDATE playlists SET last_refreshed=datetime('now'), updated_at=datetime('now') WHERE id=?").run(pl.id);
     })();
+
+    if (pl.source_type === 'xtream' && pl.source_server && pl.source_username && pl.source_password) {
+      try {
+        const epg = await importXtreamEPGForPlaylist(pl);
+        logger.info('scheduler', 'Provider login EPG refresh success', {
+          playlist_id: pl.id,
+          source_id: epg.source_id,
+          channels: epg.loaded,
+          programmes: epg.programme_count,
+        });
+      } catch (epgError) {
+        logger.warn('scheduler', 'Provider login EPG refresh failed', {
+          playlist_id: pl.id,
+          error: sanitizeXtreamEPGError(epgError),
+        });
+      }
+    }
 
     console.log(`[scheduler] Playlist "${pl.name}" refreshed — ${counts.importedLive}/${counts.totalEntries} live channels imported (${counts.skippedVodLike} VOD-like entries skipped)`);
     logger.info('scheduler', 'Playlist scheduled refresh success', {

--- a/backend/src/utils/provider-login.js
+++ b/backend/src/utils/provider-login.js
@@ -58,4 +58,4 @@ async function fetchXtreamChannels({ source_server, source_username, source_pass
   return { authUrl, channels: channelRows };
 }
 
-module.exports = { buildPlayerApiUrl, buildXtreamLiveStreamUrl, fetchXtreamChannels };
+module.exports = { normalizeBase, buildPlayerApiUrl, buildXtreamLiveStreamUrl, fetchXtreamChannels };

--- a/backend/src/utils/xtream-epg.js
+++ b/backend/src/utils/xtream-epg.js
@@ -1,0 +1,82 @@
+const fetch = require('node-fetch');
+const db = require('../db');
+const { parseXMLTVBuffer } = require('./xmltv');
+const { saveEPGCache } = require('./xmltv-merge');
+const { countProgrammeEntriesFromBuffer } = require('./xmltv-programme-count');
+const { buildHttpStatusError, redactSensitiveUrls } = require('./http-errors');
+const { queueGuideIndex } = require('./guide-indexer');
+const { normalizeBase } = require('./provider-login');
+
+const DATA_DIR = process.env.DATA_DIR || './data';
+
+function buildXtreamXmltvUrl(server, username, password) {
+  const base = normalizeBase(server);
+  const qs = new URLSearchParams({
+    username: username || '',
+    password: password || '',
+  });
+  return `${base}/xmltv.php?${qs.toString()}`;
+}
+
+function getSourceName(playlist) {
+  return `${playlist.name} (Provider Login EPG)`;
+}
+
+function ensureProviderEPGSource(playlist) {
+  const name = getSourceName(playlist);
+  const existing = db.prepare('SELECT * FROM epg_sources WHERE user_id = ? AND name = ?').get(playlist.user_id, name);
+  if (existing) return existing;
+
+  const result = db.prepare('INSERT INTO epg_sources (user_id, name, url, auto_refresh, refresh_interval) VALUES (?,?,?,?,?)')
+    .run(playlist.user_id, name, null, 0, playlist.refresh_interval || 24);
+  return db.prepare('SELECT * FROM epg_sources WHERE id = ?').get(result.lastInsertRowid);
+}
+
+function storeEPGChannels(sourceId, channels, cachePath, cacheSize, programmeCount = 0) {
+  const insert = db.prepare('INSERT INTO epg_channels (source_id, tvg_id, name, icon) VALUES (?,?,?,?)');
+  const valid = channels.filter(c => (c.tvg_id || c.id) && (c.name || '').trim());
+
+  db.transaction(() => {
+    db.prepare('DELETE FROM epg_channels WHERE source_id = ?').run(sourceId);
+    valid.forEach(c => insert.run(sourceId, c.tvg_id || c.id, c.name, c.icon || ''));
+    db.prepare(`
+      UPDATE epg_sources
+      SET last_fetched=datetime('now'), channel_count=?, programme_count=?, cache_path=?, cache_size=?,
+          cache_updated=datetime('now'), last_refreshed=datetime('now')
+      WHERE id=?
+    `).run(valid.length, Number(programmeCount) || 0, cachePath || null, cacheSize || 0, sourceId);
+  })();
+
+  return valid.length;
+}
+
+async function importXtreamEPGForPlaylist(playlist) {
+  if (!playlist?.source_server || !playlist?.source_username || !playlist?.source_password) {
+    throw new Error('Provider EPG import requires complete provider credentials.');
+  }
+
+  const url = buildXtreamXmltvUrl(playlist.source_server, playlist.source_username, playlist.source_password);
+  const response = await fetch(url, { timeout: 120000, follow: 10, compress: true });
+  if (!response.ok) throw buildHttpStatusError(response.status);
+
+  const buf = await response.buffer();
+  const channels = await parseXMLTVBuffer(buf);
+  const src = ensureProviderEPGSource(playlist);
+  const { cachePath, size } = saveEPGCache(DATA_DIR, src.id, buf);
+  const programmeCount = countProgrammeEntriesFromBuffer(buf);
+  const loaded = storeEPGChannels(src.id, channels, cachePath, size, programmeCount);
+  queueGuideIndex(src.id, cachePath);
+  try { require('../routes/guide').clearCache(); } catch {}
+
+  return { source_id: src.id, loaded, cache_size: size, programme_count: programmeCount };
+}
+
+function sanitizeXtreamEPGError(error) {
+  return redactSensitiveUrls(error?.message || String(error));
+}
+
+module.exports = {
+  buildXtreamXmltvUrl,
+  importXtreamEPGForPlaylist,
+  sanitizeXtreamEPGError,
+};

--- a/backend/src/utils/xtream-epg.js
+++ b/backend/src/utils/xtream-epg.js
@@ -19,13 +19,36 @@ function buildXtreamXmltvUrl(server, username, password) {
 }
 
 function getSourceName(playlist) {
-  return `${playlist.name} (Provider Login EPG)`;
+  return `${playlist.name} (Provider Login EPG #${playlist.id})`;
+}
+
+function getSourceSuffix(playlist) {
+  return `(Provider Login EPG #${playlist.id})`;
 }
 
 function ensureProviderEPGSource(playlist) {
   const name = getSourceName(playlist);
-  const existing = db.prepare('SELECT * FROM epg_sources WHERE user_id = ? AND name = ?').get(playlist.user_id, name);
-  if (existing) return existing;
+  const suffix = getSourceSuffix(playlist);
+
+  const stableExisting = db.prepare(`
+    SELECT * FROM epg_sources
+    WHERE user_id = ? AND name LIKE ?
+    ORDER BY id ASC
+    LIMIT 1
+  `).get(playlist.user_id, `% ${suffix}`);
+
+  const legacyName = `${playlist.name} (Provider Login EPG)`;
+  const legacyExisting = stableExisting || db.prepare('SELECT * FROM epg_sources WHERE user_id = ? AND name = ? ORDER BY id ASC LIMIT 1')
+    .get(playlist.user_id, legacyName);
+
+  const existing = stableExisting || legacyExisting;
+  if (existing) {
+    if (existing.name !== name || existing.url !== null || existing.refresh_interval !== (playlist.refresh_interval || 24)) {
+      db.prepare('UPDATE epg_sources SET name=?, url=NULL, refresh_interval=? WHERE id=?')
+        .run(name, playlist.refresh_interval || 24, existing.id);
+    }
+    return db.prepare('SELECT * FROM epg_sources WHERE id = ?').get(existing.id);
+  }
 
   const result = db.prepare('INSERT INTO epg_sources (user_id, name, url, auto_refresh, refresh_interval) VALUES (?,?,?,?,?)')
     .run(playlist.user_id, name, null, 0, playlist.refresh_interval || 24);


### PR DESCRIPTION
### Motivation
- Users adding an Xtream (Provider login) playlist reported channels import worked but the provider's XMLTV EPG at `/xmltv.php?username=...&password=...` was not being discovered or imported. 
- The change implements upstream Xtream XMLTV discovery and ingestion using stored provider base URL + credentials so provider-hosted EPG is available automatically. 
- Credentials must never be leaked and EPG failures must not break playlist import/refresh workflows.

### Description
- Add a reusable helper `backend/src/utils/xtream-epg.js` that builds the provider `/xmltv.php` URL from the stored base URL, username and password, fetches and parses XMLTV, saves the cache via the existing EPG cache mechanism, and writes parsed channels into `epg_channels` while keeping the EPG source URL `null` (credentials are not stored in a public URL).
- Wire provider EPG import into the Provider Login import flow in `backend/src/routes/playlists.js` so a provider import will attempt to fetch the upstream XMLTV after channel import and return a non-fatal `epg_warning` when EPG ingestion fails while sanitizing logged errors.
- Run the same provider EPG ingestion during scheduled playlist refreshes in `backend/src/scheduler.js` so provider EPG remains up to date without causing playlist refresh failures when the EPG endpoint is unavailable.
- Export and reuse the Xtream base normalizer from `backend/src/utils/provider-login.js` so URL construction for player API and XMLTV uses the same base handling, and add a small sanitizer wrapper so error messages logged or returned do not expose credentials.

### Testing
- Verified Xtream URL generation with `node -e "const u=require('./backend/src/utils/provider-login'); const x=require('./backend/src/utils/xtream-epg'); console.log(u.buildPlayerApiUrl('http://h/','a','b')); console.log(x.buildXtreamXmltvUrl('http://h/','a','b'))"` which printed the expected player API and xmltv endpoints.
- Verified the app builds successfully with `npm run build` (frontend build completed without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43bac8a8588331ad7fa04f4f53743c)