### PR TITLE
Add multi-arch Docker publish workflow (amd64 & arm64)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,6 @@ on:
       - main
     tags:
       - 'v*.*.*'
-      - '[0-9]+.[0-9]+.[0-9]+'
   release:
     types:
       - published

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,67 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+      - '[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: rroy676/stationarr
+
+jobs:
+  docker:
+    name: Build and publish Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{raw}}
+            type=ref,event=tag
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push multi-platform image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ The branding package also includes additional PNG sizes, SVG versions, horizonta
 ## Quick start — Docker (recommended)
 
 **Option A — Docker Hub (easiest):**
+
+The published `rroy676/stationarr` image supports both `linux/amd64` and `linux/arm64`.
+
 ```bash
 docker run -d \
   --name stationarr \


### PR DESCRIPTION
### Motivation
- Fixes #73 by enabling publishing of a multi-architecture Docker image that includes `linux/amd64` and `linux/arm64` manifests. 
- The goal is to keep the existing image name and tag conventions while ensuring users on ARM64 can pull the official image. 

### Description
- Added a new GitHub Actions workflow at `.github/workflows/docker-publish.yml` that configures `docker/setup-qemu-action@v3`, `docker/setup-buildx-action@v3`, and `docker/build-push-action@v6` to build and push multi-platform images. 
- The workflow preserves the existing Docker Hub image name `rroy676/stationarr` and publishes `latest` on the default branch plus semver/ref tags from release tags. 
- The build is configured to publish `platforms: linux/amd64,linux/arm64` and uses `docker/metadata-action@v5` to generate tags and labels. 
- Minor README note added to document that the published image now supports both `amd64` and `arm64`, and no application code or runtime behavior was changed. 

### Testing
- Ran a static workflow validation script that checked `.github/workflows/docker-publish.yml` contains `IMAGE_NAME: rroy676/stationarr`, `platforms: linux/amd64,linux/arm64`, and required actions, and it passed. 
- Ran `rg` checks for the expected buildx/qemu/login/push configuration and GitHub secrets references (`DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`), and they were found. 
- Verified staged changes with `git diff`/`git status` to confirm only CI/workflow and README were modified, and the commit was created successfully. 
- Note: the workflow has been added and is ready to run on pushes to `main`, tags matching `v*.*.*` or `X.Y.Z`, and on release publish; a full end-to-end publish test requires running the workflow in GitHub Actions (push/tag or manual dispatch) which will validate that Docker Hub receives the manifest list for both platforms.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43c59b54948331a6a2f569c1307e5d)