### PR TITLE
Add Docker Build Check workflow

### DIFF
--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -1,0 +1,28 @@
+name: Docker Build Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker-build:
+    name: Docker build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: true
+          tags: stationarr:test


### PR DESCRIPTION
### Motivation
- Add a PR-safe CI step that verifies the repository's `Dockerfile` can build locally before changes are merged, without publishing images or requiring Docker Hub credentials.

### Description
- Add `.github/workflows/docker-build-check.yml` which runs on `pull_request` and `push` to `main`, uses `ubuntu-latest`, checks out the repo, sets up Docker Buildx, and builds the Docker image from `./Dockerfile` as the local tag `stationarr:test` with `push: false` and `load: true` (build-only).

### Testing
- Verified the workflow YAML parses successfully with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-build-check.yml"); puts "YAML OK"'`, which printed `YAML OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43cf72b1cc833180b9c4b32604e8ed)