### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,75 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "deps"
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"
+      - "backend"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      backend-npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"
+      - "frontend"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      frontend-npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
### Motivation
- Add a Dependabot configuration to automatically open dependency update PRs for npm, GitHub Actions, and Docker on a weekly cadence.  
- Limit simultaneous open PRs to avoid noise and group minor/patch npm updates to reduce churn.  
- Ensure clear labels and commit-message prefixes for easier triage and to avoid enabling automatic merging.  

### Description
- Add a single file ` .github/dependabot.yml` that defines 5 update jobs: npm at `/`, `/backend`, and `/frontend`, plus `github-actions` and `docker` at `/`.  
- All jobs use a weekly `schedule` and an `open-pull-requests-limit` of `5`.  
- npm jobs include grouping for `minor` and `patch` updates to consolidate small updates.  
- Each job applies descriptive `labels` and `commit-message` prefixes and explicitly does not enable automatic merging.  

### Testing
- Validated the YAML structure with `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); raise "bad version" unless data["version"] == 2; raise "bad updates" unless data["updates"].length == 5; puts "YAML valid"'` which succeeded.  
- Confirmed only ` .github/dependabot.yml` was added and staged via `git diff --cached --name-only`.  
- Committed the file and opened a PR titled `Add Dependabot configuration` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43d08077608331a723aeb2ec6ce92a)