### PR TITLE
chore: reduce Dependabot PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "npm"
@@ -20,7 +20,7 @@ updates:
     directory: "/backend"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "npm"
@@ -38,7 +38,7 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "npm"
@@ -56,18 +56,22 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "github-actions"
     commit-message:
       prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "docker"


### PR DESCRIPTION
### Motivation
- Reduce Dependabot pull request noise by limiting concurrent open PRs and grouping related updates to avoid flooding the repository.
- Preserve weekly scheduling and ensure coverage for `npm` at `/`, `npm` at `/backend`, `npm` at `/frontend`, `github-actions`, and `docker`.

### Description
- Set `open-pull-requests-limit: 1` for each update block (root `npm`, `/backend` `npm`, `/frontend` `npm`, `github-actions`, and `docker`).
- Retained weekly `schedule` and kept `npm` minor/patch groups: `npm-minor-patch`, `backend-npm-minor-patch`, and `frontend-npm-minor-patch` so minor and patch updates are grouped by directory.
- Added a `github-actions` group with a `patterns: ["*"]` entry to consolidate all Actions updates into grouped PRs.
- Did not enable auto-merge and limited the change to only the ` .github/dependabot.yml` file.

### Testing
- Validated YAML structure with `ruby -e 'require "yaml"; ...'`, which confirmed `version: 2` and `5` update blocks and succeeded.
- Attempted YAML validation with Python but the environment lacked the `yaml` module so that check failed due to the missing dependency.
- Confirmed only ` .github/dependabot.yml` changed via `git diff --name-only` and committed the change with a descriptive commit message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43d464faf883319f3bfa47f7ee05c0)