### PR TITLE
Add regenerate endpoint and UI for Combined M3U token

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The branding package also includes additional PNG sizes, SVG versions, horizonta
 
 ### Output
 - Hosted M3U URL per playlist — use directly in any IPTV player
-- Combined M3U URL — one player URL with a dedicated user-level token that includes enabled channels from all of your playlists
+- Combined M3U URL — one player URL with a dedicated user-level token that includes enabled channels from all of your playlists; regenerate the token if it is exposed to invalidate old Combined M3U URLs
 - Hosted EPG URL — merged XMLTV from all mapped sources with timeshift applied, gzip compressed
 - Xtream Codes API (`player_api.php`, live stream redirect, `xmltv.php`)
 

--- a/backend/src/routes/playlists.js
+++ b/backend/src/routes/playlists.js
@@ -15,6 +15,18 @@ function genXtreamCreds() {
   return { xtream_user: nanoid(12), xtream_pass: nanoid(16) };
 }
 
+function generateCombinedSlug() {
+  let slug;
+  do {
+    slug = nanoid(16);
+  } while (db.prepare('SELECT id FROM users WHERE combined_slug = ?').get(slug));
+  return slug;
+}
+
+function getBaseUrl(req) {
+  return process.env.BASE_URL || `${req.protocol}://${req.get('host')}`;
+}
+
 function buildSourceUrl(body) {
   // Provider login uses Xtream player_api endpoint
   if (body.source_type === 'xtream' && body.source_server) {
@@ -61,6 +73,18 @@ router.post('/', (req, res) => {
     JOIN users u ON u.id = p.user_id
     WHERE p.id = ?
   `).get(result.lastInsertRowid));
+});
+
+
+// POST /api/playlists/combined-token/regenerate
+router.post('/combined-token/regenerate', (req, res) => {
+  const combinedSlug = generateCombinedSlug();
+  db.prepare("UPDATE users SET combined_slug = ? WHERE id = ?").run(combinedSlug, req.user.id);
+
+  res.json({
+    combined_slug: combinedSlug,
+    combined_m3u_url: `${getBaseUrl(req)}/api/serve/combined/${combinedSlug}/playlist.m3u`,
+  });
 });
 
 // GET /api/playlists/:id

--- a/docs/API.md
+++ b/docs/API.md
@@ -154,6 +154,22 @@ Automatically match EPG IDs (and optionally logos) to channels in a playlist by 
 
 ---
 
+
+### POST /playlists/combined-token/regenerate
+Regenerates the authenticated user's dedicated Combined M3U token. The previous Combined M3U URL stops working immediately because `/serve/combined/:token/playlist.m3u` only accepts the current `combined_slug` for that user.
+
+**Auth:** required
+
+**Response**
+```json
+{
+  "combined_slug": "newCombinedToken",
+  "combined_m3u_url": "http://yourhost/api/serve/combined/newCombinedToken/playlist.m3u"
+}
+```
+
+---
+
 ## Public Serve Endpoints (no auth)
 
 These endpoints are publicly accessible using either a playlist `slug` or the dedicated combined playlist `token`. Treat slugs and tokens as secrets.
@@ -162,7 +178,7 @@ These endpoints are publicly accessible using either a playlist `slug` or the de
 Returns the playlist as an M3U file, including only enabled channels.
 
 ### GET /serve/combined/:token/playlist.m3u
-Returns one combined M3U file containing enabled channels from all playlists owned by the user that owns the dedicated combined token. This route does not accept individual playlist slugs. Playlists follow the dashboard order, and channels keep each playlist's channel order.
+Returns one combined M3U file containing enabled channels from all playlists owned by the user that owns the dedicated combined token. This route does not accept individual playlist slugs. Playlists follow the dashboard order, and channels keep each playlist's channel order. Regenerating the user's combined token invalidates old Combined M3U URLs, which then return 404.
 
 ### GET /serve/:slug/epg.xml
 Returns a minimal XMLTV file listing the channel metadata for all mapped EPG IDs.

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -78,6 +78,7 @@ export const playlists = {
   update: (id, body) => put(`/playlists/${id}`, body),
   remove:      (id)       => del(`/playlists/${id}`),
   regenXtream: (id)       => post(`/playlists/${id}/regen-xtream`),
+  regenCombinedToken: () => post('/playlists/combined-token/regenerate'),
   import: (id, body) => post(`/playlists/${id}/import`, body),
   refresh: (id)       => post(`/playlists/${id}/refresh`),
 };

--- a/frontend/src/components/ServeModal.jsx
+++ b/frontend/src/components/ServeModal.jsx
@@ -18,6 +18,7 @@ export default function ServeModal({ playlist: initialPlaylist, onClose }) {
   const [playlist, setPlaylist] = useState(initialPlaylist);
   const [copied,   setCopied]   = useState('');
   const [regen,    setRegen]    = useState(false);
+  const [regenCombined, setRegenCombined] = useState(false);
 
   const base = window.location.origin;
 
@@ -34,6 +35,20 @@ export default function ServeModal({ playlist: initialPlaylist, onClose }) {
       navigator.clipboard.writeText(text).then(done).catch(() => fallbackCopy(text, done));
     } else {
       fallbackCopy(text, done);
+    }
+  };
+
+  const regenCombinedToken = async () => {
+    if (!confirm('Regenerate Combined M3U token? Old Combined M3U URLs will stop working immediately.')) return;
+    setRegenCombined(true);
+    try {
+      const updated = await api.regenCombinedToken();
+      setPlaylist(current => ({ ...current, combined_slug: updated.combined_slug }));
+      toast('Combined M3U token regenerated', 'success');
+    } catch (e) {
+      toast(e.message, 'error');
+    } finally {
+      setRegenCombined(false);
     }
   };
 
@@ -65,7 +80,17 @@ export default function ServeModal({ playlist: initialPlaylist, onClose }) {
             <p className="text-xs text-muted">For players that accept a raw M3U URL. Use Combined M3U to include all of your playlists in one URL</p>
             <UrlRow label="M3U playlist" url={m3uUrl} copied={copied === 'm3u'} onCopy={() => copy(m3uUrl, 'm3u')} />
             {combinedM3uUrl && (
-              <UrlRow label="Combined M3U" url={combinedM3uUrl} copied={copied === 'combined-m3u'} onCopy={() => copy(combinedM3uUrl, 'combined-m3u')} />
+              <UrlRow
+                label="Combined M3U"
+                url={combinedM3uUrl}
+                copied={copied === 'combined-m3u'}
+                onCopy={() => copy(combinedM3uUrl, 'combined-m3u')}
+                action={
+                  <button className="btn btn-sm btn-danger" onClick={regenCombinedToken} disabled={regenCombined}>
+                    <RefreshCw size={12} /> {regenCombined ? 'Regenerating...' : 'Regenerate token'}
+                  </button>
+                }
+              />
             )}
             <UrlRow label="EPG (XMLTV)"  url={epgUrl} copied={copied === 'epg'} onCopy={() => copy(epgUrl, 'epg')} />
           </div>
@@ -130,10 +155,13 @@ function CredBox({ label, value, copyKey, copied, onCopy }) {
   );
 }
 
-function UrlRow({ label, url, copied, onCopy }) {
+function UrlRow({ label, url, copied, onCopy, action }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-      <span className="text-xs text-muted" style={{ fontWeight: 500 }}>{label}</span>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+        <span className="text-xs text-muted" style={{ fontWeight: 500 }}>{label}</span>
+        {action}
+      </div>
       <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
         <input className="input mono" value={url} readOnly style={{ flex: 1, fontSize: 11 }} onClick={e => e.target.select()} />
         <button className="btn btn-sm btn-icon" onClick={onCopy} title="Copy"><Copy size={13} /></button>


### PR DESCRIPTION
### Motivation
- Provide a way for authenticated users to rotate their Combined M3U token when a combined URL is exposed so the old URL stops working.
- Keep the change focused on token rotation only and avoid modifying existing individual playlist serving behavior.

### Description
- Added authenticated backend endpoint `POST /api/playlists/combined-token/regenerate` that generates a secure unique token via `nanoid`, updates `users.combined_slug` for `req.user.id`, and returns `combined_slug` plus a full `combined_m3u_url` (uses `process.env.BASE_URL` or request host). 
- Implemented helper functions `generateCombinedSlug()` and `getBaseUrl(req)` in `backend/src/routes/playlists.js` and added the route under the authenticated playlists router so a user cannot rotate another user's token. 
- Added frontend API helper `playlists.regenCombinedToken()` and a `Regenerate token` button in `frontend/src/components/ServeModal.jsx` that asks for confirmation, warns that old Combined M3U URLs will stop working, updates the displayed Combined M3U URL immediately on success, and preserves existing copy/open actions; `UrlRow` was extended to accept an `action` slot. 
- Updated `docs/API.md` with the new endpoint and noted that regenerating the token invalidates old Combined M3U URLs, and amended `README.md` output docs to mention token regeneration for exposed URLs.
- Validation notes: the endpoint requires authentication and updates only `req.user.id`, and the public combined-serving route (`GET /api/serve/combined/:token/playlist.m3u`) continues to look up users by `combined_slug` so the previous combined token no longer matches and effectively returns 404 after rotation; individual playlist serve routes were not changed.

### Testing
- Ran the frontend production build with `npm run build`, which completed successfully.
- Attempted `npm run docker:build` for the Docker build check but it failed in this environment because Docker is not installed (`docker: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43dffd6020833182c6e828f7930555)