### PR TITLE
Manual Release: add optional release_notes and maintain CHANGELOG

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -7,6 +7,10 @@ on:
         description: 'Release version, without a leading v (example: 1.2.1)'
         required: true
         type: string
+      release_notes:
+        description: 'Release notes for the changelog and GitHub release body (strongly recommended)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -85,9 +89,52 @@ jobs:
             exit 1
           fi
 
+      - name: Update changelog and release notes
+        env:
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          VERSION='${{ steps.version.outputs.version }}'
+          RELEASE_DATE=$(date -u +%F)
+          export VERSION RELEASE_DATE
+
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          version = os.environ['VERSION']
+          release_date = os.environ['RELEASE_DATE']
+          notes = os.environ.get('RELEASE_NOTES', '').strip()
+
+          if not notes:
+              notes = f'Stationarr v{version}'
+
+          section = f'## v{version} - {release_date}\n\n{notes}\n'
+          body = section
+
+          Path('release-body.md').write_text(body, encoding='utf-8')
+
+          changelog_path = Path('CHANGELOG.md')
+          if changelog_path.exists():
+              changelog = changelog_path.read_text(encoding='utf-8')
+          else:
+              changelog = '# Changelog\n'
+
+          if not changelog.startswith('# Changelog'):
+              changelog = '# Changelog\n\n' + changelog.lstrip()
+
+          lines = changelog.splitlines()
+          if lines and lines[0].strip() == '# Changelog':
+              rest = '\n'.join(lines[1:]).lstrip('\n')
+              changelog = '# Changelog\n\n' + section + ('\n' + rest if rest else '')
+          else:
+              changelog = '# Changelog\n\n' + section + '\n' + changelog.lstrip()
+
+          changelog_path.write_text(changelog.rstrip() + '\n', encoding='utf-8')
+          PY
+
       - name: Verify release changes
         run: |
-          allowed='^(package.json|package-lock.json|backend/package.json|backend/package-lock.json)$'
+          allowed='^(CHANGELOG.md|package.json|package-lock.json|backend/package.json|backend/package-lock.json)$'
           changed=$(git diff --name-only)
 
           if [ -z "$changed" ]; then
@@ -106,7 +153,7 @@ jobs:
       - name: Commit version bump
         run: |
           VERSION='${{ steps.version.outputs.version }}'
-          git add package.json backend/package.json
+          git add CHANGELOG.md package.json backend/package.json
           [ -f package-lock.json ] && git add package-lock.json
           [ -f backend/package-lock.json ] && git add backend/package-lock.json
           git commit --allow-empty -m "chore: release v$VERSION"
@@ -126,4 +173,4 @@ jobs:
           gh release create "$TAG" \
             --target main \
             --title "Stationarr $TAG" \
-            --notes "Stationarr $TAG"
+            --notes-file release-body.md


### PR DESCRIPTION
### Motivation
- Prevent empty GitHub releases and ensure a single-source-of-truth changelog by letting the manual release include release notes that are persisted to `CHANGELOG.md` and reused for the GitHub release body.

### Description
- Add an optional `workflow_dispatch` input `release_notes` to the Manual Release workflow so notes can be entered at dispatch time.
- Add a release step that generates `release-body.md` and creates or updates root `CHANGELOG.md` by inserting a section `## vX.Y.Z - YYYY-MM-DD` immediately under the `# Changelog` heading using the provided notes or falling back to `Stationarr vX.Y.Z` when empty.
- Include `CHANGELOG.md` in the release verification and commit staging and change the GitHub release invocation to use `--notes-file release-body.md` so the same content is used for both changelog and release body.
- Leave Docker publish behavior and other release/version bump logic unchanged.

### Testing
- Loaded the updated workflow with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/manual-release.yml'); puts 'yaml ok'"` and it parsed successfully.
- Simulated the changelog/release-body script in temporary directories with both multiline `RELEASE_NOTES` and an empty fallback, and both runs completed successfully and produced the expected `CHANGELOG.md` and `release-body.md` content.
- Ran `git diff --check`/diff/stat to ensure no whitespace or unexpected changes and committed the workflow update successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a441fdeabc483319383cd396c020d11)