### PR TITLE
fix: preserve manual release note formatting

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -90,12 +90,14 @@ jobs:
           fi
 
       - name: Update changelog and release notes
-        env:
-          RELEASE_NOTES: ${{ inputs.release_notes }}
         run: |
           VERSION='${{ steps.version.outputs.version }}'
           RELEASE_DATE=$(date -u +%F)
           export VERSION RELEASE_DATE
+
+          cat > release-notes-input.md <<'RELEASE_NOTES_EOF'
+          ${{ inputs.release_notes }}
+          RELEASE_NOTES_EOF
 
           python - <<'PY'
           import os
@@ -103,15 +105,15 @@ jobs:
 
           version = os.environ['VERSION']
           release_date = os.environ['RELEASE_DATE']
-          notes = os.environ.get('RELEASE_NOTES', '').strip()
+          notes = Path('release-notes-input.md').read_text(encoding='utf-8')
 
-          if not notes:
-              notes = f'Stationarr v{version}'
+          if not notes.strip():
+              notes = f'Stationarr v{version}\n'
 
-          section = f'## v{version} - {release_date}\n\n{notes}\n'
-          body = section
+          notes = notes.rstrip('\n') + '\n'
+          section = f'## v{version} - {release_date}\n\n{notes}'
 
-          Path('release-body.md').write_text(body, encoding='utf-8')
+          Path('release-body.md').write_text(section, encoding='utf-8')
 
           changelog_path = Path('CHANGELOG.md')
           if changelog_path.exists():
@@ -131,6 +133,8 @@ jobs:
 
           changelog_path.write_text(changelog.rstrip() + '\n', encoding='utf-8')
           PY
+
+          rm release-notes-input.md
 
       - name: Verify release changes
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 ## v1.2.2 - 2026-06-30
 
-### Fixed - Fixed app version reporting so `/api/health` and the Settings page show the correct release version. - Fixed a release packaging issue where the Docker image could contain newer app code while still reporting an older internal version.  ### Added - Added Docker build support for passing the release version into the app through `APP_VERSION`. - Added a release version guard so Docker releases fail if the Git tag and `package.json` version do not match. - Added a Manual Release workflow to automate version bumping, tagging, and GitHub release creation. - Added changelog support so release notes are recorded in `CHANGELOG.md`.  ### Changed - `/api/health` now reports `APP_VERSION` when set, with a fallback to the root `package.json` version for local development. - Future releases now have a safer flow to keep GitHub tags, Docker image versions, app health version, and the Settings page version aligned.
+### Fixed
+- Fixed app version reporting so `/api/health` and the Settings page show the correct release version.
+- Fixed a release packaging issue where the Docker image could contain newer app code while still reporting an older internal version.
+
+### Added
+- Added Docker build support for passing the release version into the app through `APP_VERSION`.
+- Added a release version guard so Docker releases fail if the Git tag and `package.json` version do not match.
+- Added a Manual Release workflow to automate version bumping, tagging, and GitHub release creation.
+- Added changelog support so release notes are recorded in `CHANGELOG.md`.
+
+### Changed
+- `/api/health` now reports `APP_VERSION` when set, with a fallback to the root `package.json` version for local development.
+- Future releases now have a safer flow to keep GitHub tags, Docker image versions, app health version, and the Settings page version aligned.
 
 ## v1.2.1
 


### PR DESCRIPTION
### Motivation
- The manual release workflow was collapsing multiline `workflow_dispatch` `release_notes` into a single paragraph so Markdown headings and blank lines were not rendered correctly in the GitHub release body and `CHANGELOG.md`.
- The goal is to preserve multiline markdown input exactly as entered while keeping the existing fallback and release behavior.

### Description
- Updated `.github/workflows/manual-release.yml` to write the raw `release_notes` input to a temporary heredoc file (`release-notes-input.md`) so the multiline text is preserved verbatim when read by the Python step.
- Changed the Python step to read `release-notes-input.md`, keep blank lines and headings, ensure a single trailing newline, and write the formatted section to `release-body.md` and insert it into `CHANGELOG.md` unchanged.
- Preserved the empty-notes fallback by checking `notes.strip()` and setting `notes = f'Stationarr v{version}\n'` when empty, and removed the temporary file after use.
- Fixed the existing flattened `v1.2.2` `CHANGELOG.md` entry so `### Fixed`, `### Added`, and `### Changed` render as proper Markdown headings with bullet lists.

### Testing
- Ran `git diff --check` to ensure no whitespace issues and it passed successfully.
- Validated the workflow YAML and heredoc presence with a Ruby script parsing `.github/workflows/manual-release.yml` to assert the heredoc is present and the input expression is not indented, and the check passed.
- Simulated the release-note insertion in a temporary directory by writing a multiline Markdown sample to `release-notes-input.md`, running the same Python logic, and asserting that `release-body.md` and `CHANGELOG.md` contain `### Fixed`, `### Added`, and `### Changed` headings on separate lines, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44236c3af483319a5f68abdce19a41)