### PR TITLE
Add Docker smoke test to Docker Build Check workflow

### DIFF
--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -25,4 +25,35 @@ jobs:
           file: ./Dockerfile
           push: false
           load: true
-          tags: stationarr:test
+          tags: stationarr:smoke-test
+          build-args: |
+            APP_VERSION=smoke-test
+
+      - name: Run Docker smoke test
+        run: |
+          docker run -d --name stationarr-smoke-test -p 3000:3000 stationarr:smoke-test
+
+          health_response=""
+          for attempt in {1..30}; do
+            if health_response=$(curl --silent --show-error --fail http://localhost:3000/api/health); then
+              echo "Health response: ${health_response}"
+              if echo "${health_response}" | grep -q '"ok":true'; then
+                exit 0
+              fi
+
+              echo "/api/health did not report ok true."
+              exit 1
+            fi
+
+            echo "Waiting for Stationarr to start (${attempt}/30)..."
+            sleep 1
+          done
+
+          echo "Stationarr did not become healthy within 30 seconds."
+          echo "Last health response: ${health_response}"
+          docker logs stationarr-smoke-test
+          exit 1
+
+      - name: Stop Docker smoke test container
+        if: always()
+        run: docker rm -f stationarr-smoke-test || true


### PR DESCRIPTION
### Motivation
- Add a CI-level smoke test that verifies the built Docker image actually starts and the HTTP API responds, so pull requests fail when the image is non-functional.
- Run the image locally in the runner (no push) and validate runtime behavior by calling the health endpoint `/api/health`.

### Description
- Update the existing workflow to build the image tagged `stationarr:smoke-test` with `push: false`, `load: true`, and the build arg `APP_VERSION=smoke-test` so the image is local-only and versioned for testing.
- Add a step that runs the image as a container named `stationarr-smoke-test` with `docker run -d --name stationarr-smoke-test -p 3000:3000 stationarr:smoke-test` and retries `curl` against `/api/health` for up to 30 seconds.
- Fail the job unless the health endpoint response contains `"ok":true`, print the health response to logs, dump container logs on timeout/failure, and always stop/remove the test container with `docker rm -f stationarr-smoke-test` in an `if: always()` cleanup step.

### Testing
- Parsed the modified workflow with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker-build-check.yml'); puts 'YAML OK'"`, which succeeded.
- Ran `git diff --check` to validate whitespace/format issues, which reported no problems.
- Attempted a local `docker build --build-arg APP_VERSION=smoke-test -t stationarr:smoke-test .` but the Docker CLI is not available in this environment, so a local image build was not executed here (the smoke test will run in CI where Docker is available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4427e8488c83318b441535c3975da3)