### PR TITLE
fix: stream large XMLTV uploads directly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ REGISTRATION_OPEN=true
 SCRAPER_URL=http://stationarr-epg:3000
 SCRAPER_CHANNELS_PATH=/app/data/scraper/channels.xml
 TRUST_PROXY=false
+# Maximum raw XMLTV upload size. This does not change the 20 MB JSON API limit.
+EPG_UPLOAD_MAX_SIZE_MB=250

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -66,7 +66,7 @@ if (fs.existsSync(DIST)) {
   app.get('*', (_req, res) => res.sendFile(path.join(DIST, 'index.html')));
 }
 
-app.listen(PORT, () => {
+if (require.main === module) app.listen(PORT, () => {
   console.log(`Stationarr running on http://localhost:${PORT}`);
   logger.info('system', 'Stationarr startup', { port: PORT, version });
   // Start background auto-refresh scheduler
@@ -74,3 +74,5 @@ app.listen(PORT, () => {
   // Queue existing stale guide indexes for cached EPG sources
   require('./utils/guide-indexer').queueStaleGuideIndexes();
 });
+
+module.exports = app;

--- a/backend/src/routes/epg.js
+++ b/backend/src/routes/epg.js
@@ -1,13 +1,16 @@
 const router  = require('express').Router();
 const db      = require('../db');
 const requireAuth = require('../middleware/auth');
-const { parseXMLTV, parseXMLTVBuffer } = require('../utils/xmltv');
+const { parseXMLTV, parseXMLTVBuffer, parseXMLTVFile } = require('../utils/xmltv');
 const { saveEPGCache, deleteEPGCache } = require('../utils/xmltv-merge');
 const { readProgrammes } = require('../utils/epg-reader');
-const { countProgrammeEntriesFromBuffer } = require('../utils/xmltv-programme-count');
+const { countProgrammeEntriesFromBuffer, countProgrammeEntriesFromFile } = require('../utils/xmltv-programme-count');
 const fetch   = require('node-fetch');
 const path    = require('path');
 const fs      = require('fs');
+const crypto  = require('crypto');
+const { Transform } = require('stream');
+const { pipeline } = require('stream/promises');
 const logger  = require('../logger');
 const { queueGuideIndex } = require('../utils/guide-indexer');
 const { redactSensitiveUrls } = require('../utils/http-errors');
@@ -156,7 +159,6 @@ router.post('/:id/fetch', async (req, res) => {
     });
 
     // Parse from disk using SAX streaming — memory efficient
-    const { parseXMLTVFile } = require('../utils/xmltv');
     const channels = await parseXMLTVFile(tmpPath);
     const size     = fs.statSync(tmpPath).size;
 
@@ -179,24 +181,68 @@ router.post('/:id/fetch', async (req, res) => {
   }
 });
 
-// POST /api/epg/:id/upload
+function epgUploadLimitBytes() {
+  const configured = Number(process.env.EPG_UPLOAD_MAX_SIZE_MB || 250);
+  const megabytes = Number.isFinite(configured) && configured > 0 ? configured : 250;
+  return Math.floor(megabytes * 1024 * 1024);
+}
+
+function uploadSizeLimiter(maxBytes) {
+  let received = 0;
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      received += chunk.length;
+      if (received > maxBytes) {
+        const error = new Error('EPG upload exceeds configured size limit');
+        error.code = 'EPG_UPLOAD_TOO_LARGE';
+        callback(error);
+      } else {
+        callback(null, chunk);
+      }
+    },
+  });
+}
+
+// POST /api/epg/:id/upload — raw XML/XMLTV or gzip body, streamed to disk
 router.post('/:id/upload', async (req, res) => {
   const src = db.prepare('SELECT * FROM epg_sources WHERE id=? AND user_id=?').get(req.params.id, req.user.id);
   if (!src) return res.status(404).json({ error: 'Not found' });
-  const { content } = req.body;
-  if (!content) return res.status(400).json({ error: 'content required' });
+  const maxBytes = epgUploadLimitBytes();
+  const contentLength = Number(req.get('content-length'));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    req.resume();
+    return res.status(413).json({ error: `EPG upload exceeds the ${process.env.EPG_UPLOAD_MAX_SIZE_MB || 250} MB limit` });
+  }
+
+  const cacheDir = path.join(DATA_DIR, 'epg_cache');
+  const tmpPath = path.join(cacheDir, `.upload_${src.id}_${crypto.randomBytes(8).toString('hex')}.tmp`);
   try {
-    const buf      = Buffer.from(content, 'utf8');
-    const channels = await parseXMLTVBuffer(buf);
-    const { cachePath, size } = saveEPGCache(DATA_DIR, src.id, buf);
-    const programmeCount = countProgrammeEntriesFromBuffer(buf);
+    await fs.promises.mkdir(cacheDir, { recursive: true });
+    await pipeline(req, uploadSizeLimiter(maxBytes), fs.createWriteStream(tmpPath, { flags: 'wx' }));
+    const size = (await fs.promises.stat(tmpPath)).size;
+    if (!size) {
+      const error = new Error('XMLTV payload required');
+      error.code = 'EMPTY_EPG_UPLOAD';
+      throw error;
+    }
+
+    const channels = await parseXMLTVFile(tmpPath);
+    const programmeCount = await countProgrammeEntriesFromFile(tmpPath);
+    const cachePath = path.join(cacheDir, `source_${src.id}.xml`);
+    await fs.promises.rename(tmpPath, cachePath);
     storeEPGChannels(src.id, channels, cachePath, size, programmeCount);
     queueGuideIndex(src.id, cachePath);
     try { require('./guide').clearCache(); } catch {}
     logger.info('epg', 'Manual EPG source fetch success', { source_id: src.id, channels: channels.length, programmes: programmeCount });
     res.json({ loaded: channels.length, cache_size: size, cached: true, programme_count: programmeCount });
   } catch (e) {
-    res.status(500).json({ error: 'Parse failed: ' + e.message });
+    await fs.promises.unlink(tmpPath).catch(() => {});
+    if (e.code === 'EPG_UPLOAD_TOO_LARGE') {
+      return res.status(413).json({ error: `EPG upload exceeds the ${process.env.EPG_UPLOAD_MAX_SIZE_MB || 250} MB limit` });
+    }
+    const safeMessage = redactSensitiveUrls(e?.message || String(e));
+    logger.error('epg', 'Manual EPG upload failure', { source_id: src.id, error: safeMessage });
+    res.status(400).json({ error: 'Upload failed: ' + safeMessage });
   }
 });
 

--- a/backend/src/utils/xmltv-programme-count.js
+++ b/backend/src/utils/xmltv-programme-count.js
@@ -1,4 +1,6 @@
 const zlib = require('zlib');
+const fs = require('fs');
+const sax = require('sax');
 
 function looksLikeGzip(buf) {
   return Buffer.isBuffer(buf) && buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b;
@@ -19,7 +21,32 @@ function countProgrammeEntriesFromBuffer(buf) {
   }
 }
 
+async function countProgrammeEntriesFromFile(filePath) {
+  const handle = await fs.promises.open(filePath, 'r');
+  const header = Buffer.alloc(2);
+  try {
+    await handle.read(header, 0, 2, 0);
+  } finally {
+    await handle.close();
+  }
+
+  const parser = sax.createStream(true, { trim: false, normalize: false });
+  let count = 0;
+  parser.on('opentag', (node) => { if (node.name === 'programme') count += 1; });
+  const source = fs.createReadStream(filePath);
+  const input = looksLikeGzip(header) ? source.pipe(zlib.createGunzip()) : source;
+  await new Promise((resolve, reject) => {
+    input.pipe(parser);
+    source.on('error', reject);
+    input.on('error', reject);
+    parser.on('error', reject);
+    parser.on('end', resolve);
+  });
+  return count;
+}
+
 module.exports = {
   countProgrammeEntriesFromBuffer,
+  countProgrammeEntriesFromFile,
   countProgrammeEntriesFromXmlText,
 };

--- a/backend/test/epg-upload.test.js
+++ b/backend/test/epg-upload.test.js
@@ -1,0 +1,117 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const zlib = require('zlib');
+const jwt = require('jsonwebtoken');
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stationarr-upload-test-'));
+process.env.DATA_DIR = dataDir;
+process.env.JWT_SECRET = 'epg-upload-test-secret';
+process.env.EPG_UPLOAD_MAX_SIZE_MB = '25';
+process.env.NODE_ENV = 'test';
+
+const db = require('../src/db');
+const app = require('../src/index');
+
+const user = db.prepare('INSERT INTO users (username,email,password) VALUES (?,?,?)')
+  .run('upload-test', 'upload@example.test', 'unused');
+const token = jwt.sign({ id: Number(user.lastInsertRowid) }, process.env.JWT_SECRET);
+const authHeaders = { Authorization: `Bearer ${token}` };
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  server = app.listen(0, '127.0.0.1');
+  await new Promise((resolve) => server.once('listening', resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+test.after(async () => {
+  await new Promise((resolve) => server.close(resolve));
+  db.close();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+function createSource(name) {
+  return Number(db.prepare('INSERT INTO epg_sources (user_id,name) VALUES (?,?)')
+    .run(Number(user.lastInsertRowid), name).lastInsertRowid);
+}
+
+function xmltv(paddingBytes = 0) {
+  return Buffer.from(
+    '<?xml version="1.0"?><tv><channel id="news"><display-name>News</display-name></channel>' +
+    ' '.repeat(paddingBytes) +
+    '<programme channel="news" start="20260901000000 +0000" stop="20260901010000 +0000"><title>Bulletin</title></programme></tv>'
+  );
+}
+
+async function upload(sourceId, body, contentType = 'application/octet-stream') {
+  return fetch(`${baseUrl}/api/epg/${sourceId}/upload`, {
+    method: 'POST',
+    headers: { ...authHeaders, 'Content-Type': contentType },
+    body,
+  });
+}
+
+test('streams a raw XML upload larger than the global 20 MB JSON limit and updates metadata', async () => {
+  const sourceId = createSource('large raw');
+  const body = xmltv(20 * 1024 * 1024 + 1024);
+  const response = await upload(sourceId, body, 'application/xml');
+  assert.equal(response.status, 200);
+  const result = await response.json();
+  assert.equal(result.loaded, 1);
+  assert.equal(result.programme_count, 1);
+  assert.equal(result.cache_size, body.length);
+
+  const source = db.prepare('SELECT * FROM epg_sources WHERE id=?').get(sourceId);
+  assert.equal(source.channel_count, 1);
+  assert.equal(source.programme_count, 1);
+  assert.equal(fs.statSync(source.cache_path).size, body.length);
+  assert.deepEqual(db.prepare('SELECT tvg_id,name FROM epg_channels WHERE source_id=?').all(sourceId), [
+    { tvg_id: 'news', name: 'News' },
+  ]);
+});
+
+test('accepts an extensionless gzip payload using magic-byte detection', async () => {
+  const sourceId = createSource('gzip');
+  const compressed = zlib.gzipSync(xmltv());
+  const response = await upload(sourceId, compressed);
+  assert.equal(response.status, 200);
+  const result = await response.json();
+  assert.equal(result.loaded, 1);
+  assert.equal(result.programme_count, 1);
+  const cache = fs.readFileSync(db.prepare('SELECT cache_path FROM epg_sources WHERE id=?').get(sourceId).cache_path);
+  assert.deepEqual(cache.subarray(0, 2), Buffer.from([0x1f, 0x8b]));
+});
+
+test('rejects uploads over the EPG-specific limit and removes the temporary file', async () => {
+  const sourceId = createSource('too large');
+  process.env.EPG_UPLOAD_MAX_SIZE_MB = '0.001';
+  const response = await upload(sourceId, xmltv(2048));
+  assert.equal(response.status, 413);
+  assert.match((await response.json()).error, /limit/i);
+  const cacheDir = path.join(dataDir, 'epg_cache');
+  assert.equal(fs.readdirSync(cacheDir).some((name) => name.startsWith(`.upload_${sourceId}_`)), false);
+  process.env.EPG_UPLOAD_MAX_SIZE_MB = '25';
+});
+
+test('removes the temporary file when parsing fails', async () => {
+  const sourceId = createSource('invalid');
+  const response = await upload(sourceId, Buffer.from('<tv><channel id="broken"></tv>'), 'application/xml');
+  assert.equal(response.status, 400);
+  const cacheDir = path.join(dataDir, 'epg_cache');
+  assert.equal(fs.readdirSync(cacheDir).some((name) => name.startsWith(`.upload_${sourceId}_`)), false);
+  assert.equal(db.prepare('SELECT cache_path FROM epg_sources WHERE id=?').get(sourceId).cache_path, null);
+});
+
+test('keeps the normal JSON parser limit at 20 MB', async () => {
+  const response = await fetch(`${baseUrl}/api/epg`, {
+    method: 'POST',
+    headers: { ...authHeaders, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'x'.repeat(20 * 1024 * 1024 + 1) }),
+  });
+  assert.equal(response.status, 413);
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - BASE_URL=${BASE_URL:-http://localhost:3000}
       - REGISTRATION_OPEN=${REGISTRATION_OPEN:-true}
       - TRUST_PROXY=${TRUST_PROXY:-false}
+      - EPG_UPLOAD_MAX_SIZE_MB=${EPG_UPLOAD_MAX_SIZE_MB:-250}
       - SCRAPER_URL=http://stationarr-epg:3000
       # Must stay under /app/data for Stationarr; do not point to /epg/public
       - SCRAPER_CHANNELS_PATH=/app/data/scraper/channels.xml

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -59,6 +59,24 @@ async function request(method, path, body, raw = false) {
   return data;
 }
 
+async function upload(method, path, body, contentType = 'application/octet-stream') {
+  const currentToken = token();
+  const headers = { 'Content-Type': contentType };
+  if (currentToken) headers.Authorization = `Bearer ${currentToken}`;
+
+  const res = await fetch(`${BASE}${path}`, { method, headers, body });
+  const data = await res.json().catch(() => ({}));
+  if (res.status === 401) {
+    const message = data.error || data.message || 'Unauthorized';
+    localStorage.removeItem('token');
+    sessionStorage.setItem('auth_error', message);
+    if (window.location.pathname !== '/login') window.location.assign('/login');
+    throw new Error(message);
+  }
+  if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+  return data;
+}
+
 const get  = (path)        => request('GET',    path);
 const post = (path, body)  => request('POST',   path, body);
 const put  = (path, body)  => request('PUT',    path, body);
@@ -105,7 +123,7 @@ export const epg = {
   remove:     (id)        => del(`/epg/${id}`),
   channels:   (id)        => get(`/epg/${id}/channels`),
   fetch:      (id)        => post(`/epg/${id}/fetch`),
-  upload:     (id, body)  => post(`/epg/${id}/upload`, body),
+  upload:     (id, file)  => upload('POST', `/epg/${id}/upload`, file, file.type || 'application/octet-stream'),
   refresh:    (id)        => post(`/epg/${id}/refresh`),
   autoMatch:  (body)      => post('/epg/auto-match',   body),
   clearCache:  (id)        => del(`/epg/${id}/cache`),

--- a/frontend/src/components/EPGPanel.jsx
+++ b/frontend/src/components/EPGPanel.jsx
@@ -102,22 +102,18 @@ export default function EPGPanel({ sources, onClose, onChange }) {
     finally { setBusyFor(id, false); }
   };
 
-  const uploadFile = (file, id) => {
-    const reader = new FileReader();
-    reader.onload = async (e) => {
-      setBusyFor(id, 'upload');
-      try {
-        const res = await api.upload(id, { content: e.target.result });
-        toast(`Loaded ${res.loaded} channels · ${res.programme_count ?? 0} programmes · ${formatSize(res.cache_size)} cached`, 'success');
-        setOrderedSources(prev => prev.map(s => s.id === id
-          ? { ...s, channel_count: res.loaded, programme_count: res.programme_count ?? s.programme_count ?? 0, cache_size: res.cache_size, cache_updated: new Date().toISOString() }
-          : s
-        ));
-        onChange();
-      } catch (err) { toast(err.message, 'error'); }
-      finally { setBusyFor(id, false); }
-    };
-    reader.readAsText(file);
+  const uploadFile = async (file, id) => {
+    setBusyFor(id, 'upload');
+    try {
+      const res = await api.upload(id, file);
+      toast(`Loaded ${res.loaded} channels · ${res.programme_count ?? 0} programmes · ${formatSize(res.cache_size)} cached`, 'success');
+      setOrderedSources(prev => prev.map(s => s.id === id
+        ? { ...s, channel_count: res.loaded, programme_count: res.programme_count ?? s.programme_count ?? 0, cache_size: res.cache_size, cache_updated: new Date().toISOString() }
+        : s
+      ));
+      onChange();
+    } catch (err) { toast(err.message, 'error'); }
+    finally { setBusyFor(id, false); }
   };
 
   const setEditField = (k) => (e) => setEditForm(f => ({


### PR DESCRIPTION
### Motivation
- Large XMLTV EPG uploads were being read with `FileReader.readAsText()` and JSON-encoded, causing `PayloadTooLargeError` and multiple in-memory copies for big files. The intent is to make uploads memory-efficient and scoped to EPG uploads only. 

### Description
- Change the frontend to send the selected `File` directly (raw body) instead of JSON-encoding its contents and add an `upload` helper that posts a `File`/`Blob` with its content type. 
- Replace the JSON upload handler with a streaming `POST /api/epg/:id/upload` that pipes the request into a unique temporary file under the existing `epg_cache`, enforces an EPG-only size limit, detects gzip by magic bytes, parses via the streaming `parseXMLTVFile`, and atomically promotes the file to the source cache on success. 
- Add an upload-size limiter driven by `EPG_UPLOAD_MAX_SIZE_MB` (default 250) which returns HTTP 413 for oversize uploads, plus explicit cleanup of temporary files on parse/upload failure and safe error messages that redact sensitive URLs. 
- Add a streaming programme-count helper so programme counting is done from disk (preserving gzip support) and update channel/programme metadata via the existing `storeEPGChannels` flow, preserving authentication/authorization. 
- Update environment example and Docker Compose to document `EPG_UPLOAD_MAX_SIZE_MB`, and add regression tests covering raw >20 MB uploads, gzip (extensionless) payloads, upload-size rejection (413), cleanup on failure, and confirmation that normal JSON endpoints still use the 20 MB limit.

### Testing
- Ran backend unit/regression tests `npm --prefix backend test`, which passed (all tests in `backend/test/*.test.js` succeeded). 
- Built the frontend (`npm run build`) to confirm the UI bundle compiles successfully. 
- Performed syntactic checks (`node --check`) on modified backend files and ran `git diff --check`; these checks passed. 
- Added `backend/test/epg-upload.test.js` that exercises raw large uploads, gzip detection, size-limit rejection, failure cleanup, and verifies DB/cache metadata updates (tests executed as part of backend test run and included in the passing results).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a963c6e7e2c83318c1c08d54622c5f1)