### PR TITLE
feat: add URL validation and reachability checks for generated playlists

### DIFF
--- a/backend/src/routes/serve.js
+++ b/backend/src/routes/serve.js
@@ -3,6 +3,65 @@ const db     = require('../db');
 const { exportM3U } = require('../utils/m3u');
 const { mergeXMLTV, proxyEPG } = require('../utils/xmltv-merge');
 const logger = require('../logger');
+const fetch = require('node-fetch');
+
+// POST /api/serve/validate-url
+// Check a generated playlist URL from the same network location as Stationarr.
+router.post('/validate-url', async (req, res) => {
+  const { url, type } = req.body || {};
+  const warnings = [];
+
+  if (typeof url !== 'string' || !url.trim()) {
+    return res.status(400).json({ error: 'url is required' });
+  }
+
+  const value = url.trim();
+  let parsed;
+  try {
+    parsed = new URL(value);
+    if (!['http:', 'https:'].includes(parsed.protocol)) throw new Error('unsupported protocol');
+  } catch {
+    return res.status(400).json({
+      url: value,
+      reachable: false,
+      contentType: null,
+      looksValid: false,
+      warnings: ['URL must be a valid HTTP or HTTPS URL'],
+    });
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') {
+    warnings.push('This URL uses localhost and may only be reachable from the Stationarr container.');
+  }
+
+  const kind = type === 'm3u' || type === 'xmltv'
+    ? type
+    : /(?:\.m3u|get\.php)(?:$|[?#])/i.test(parsed.pathname + parsed.search) ? 'm3u' : 'xmltv';
+  let reachable = false;
+  let contentType = null;
+  let looksValid = false;
+
+  try {
+    const response = await fetch(value, { timeout: 10000, follow: 5 });
+    contentType = response.headers.get('content-type');
+    reachable = response.ok;
+    const body = await response.text();
+    looksValid = kind === 'm3u'
+      ? body.trimStart().startsWith('#EXTM3U')
+      : /<tv(?:\s|>)/i.test(body);
+  } catch (error) {
+    warnings.push(`Request failed: ${error.message}`);
+  }
+
+  if (reachable && !looksValid) {
+    warnings.push(kind === 'm3u'
+      ? 'The response does not look like an M3U playlist (missing #EXTM3U).'
+      : 'The response does not look like XMLTV data (missing <tv>).');
+  }
+
+  res.json({ url: value, reachable, contentType, looksValid, warnings });
+});
 
 // GET /api/serve/combined/:token/playlist.m3u
 // Uses a dedicated user-level share token so individual playlist slugs do not

--- a/backend/test/serve-validation.test.js
+++ b/backend/test/serve-validation.test.js
@@ -1,0 +1,100 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stationarr-serve-validation-'));
+process.env.DATA_DIR = dataDir;
+process.env.JWT_SECRET = 'test-secret';
+process.env.NODE_ENV = 'test';
+
+const app = require('../src/index');
+
+let server;
+let sourceServer;
+let baseUrl;
+let sourceUrl;
+
+test.before(async () => {
+  sourceServer = http.createServer((req, res) => {
+    if (req.url === '/playlist.m3u') {
+      res.writeHead(200, { 'Content-Type': 'audio/x-mpegurl' });
+      return res.end('#EXTM3U\n#EXTINF:-1,News\nhttp://example.test/live\n');
+    }
+    if (req.url === '/guide.xml') {
+      res.writeHead(200, { 'Content-Type': 'application/xml' });
+      return res.end('<?xml version="1.0"?><tv></tv>');
+    }
+    if (req.url === '/wrong.m3u') {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      return res.end('not a playlist');
+    }
+    res.writeHead(404);
+    res.end('not found');
+  }).listen(0, '127.0.0.1');
+  await new Promise(resolve => sourceServer.once('listening', resolve));
+  sourceUrl = `http://127.0.0.1:${sourceServer.address().port}`;
+
+  server = app.listen(0, '127.0.0.1');
+  await new Promise(resolve => server.once('listening', resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+test.after(async () => {
+  await Promise.all([
+    new Promise(resolve => server.close(resolve)),
+    new Promise(resolve => sourceServer.close(resolve)),
+  ]);
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+async function validate(url, type) {
+  const response = await fetch(`${baseUrl}/api/serve/validate-url`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url, type }),
+  });
+  return { response, body: await response.json() };
+}
+
+test('validates reachable M3U and warns about loopback URLs', async () => {
+  const { response, body } = await validate(`${sourceUrl}/playlist.m3u`, 'm3u');
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, {
+    url: `${sourceUrl}/playlist.m3u`,
+    reachable: true,
+    contentType: 'audio/x-mpegurl',
+    looksValid: true,
+    warnings: ['This URL uses localhost and may only be reachable from the Stationarr container.'],
+  });
+});
+
+test('validates XMLTV content and flags an invalid M3U response', async () => {
+  const xml = await validate(`${sourceUrl}/guide.xml`, 'xmltv');
+  assert.equal(xml.body.reachable, true);
+  assert.equal(xml.body.looksValid, true);
+  assert.equal(xml.body.contentType, 'application/xml');
+
+  const m3u = await validate(`${sourceUrl}/wrong.m3u`, 'm3u');
+  assert.equal(m3u.body.reachable, true);
+  assert.equal(m3u.body.looksValid, false);
+  assert.ok(m3u.body.warnings.length >= 2);
+  assert.match(m3u.body.warnings[1], /does not look like an M3U/i);
+});
+
+test('reports failed HTTP checks and rejects missing URLs', async () => {
+  const failed = await validate(`${sourceUrl}/missing.m3u`, 'm3u');
+  assert.equal(failed.body.reachable, false);
+  assert.equal(failed.body.looksValid, false);
+  assert.ok(failed.body.warnings.length >= 1);
+  assert.match(failed.body.warnings[0], /localhost|127\.0\.0\.1/i);
+
+  const response = await fetch(`${baseUrl}/api/serve/validate-url`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+  assert.equal(response.status, 400);
+});

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -99,6 +99,7 @@ export const playlists = {
   regenCombinedToken: () => post('/playlists/combined-token/regenerate'),
   import: (id, body) => post(`/playlists/${id}/import`, body),
   refresh: (id)       => post(`/playlists/${id}/refresh`),
+  validateUrl: (url, type) => post('/serve/validate-url', { url, type }),
 };
 
 export const channels = {

--- a/frontend/src/components/ServeModal.jsx
+++ b/frontend/src/components/ServeModal.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Copy, Check, ExternalLink, RefreshCw } from 'lucide-react';
+import { Copy, Check, ExternalLink, RefreshCw, X } from 'lucide-react';
 import { playlists as api } from '../api.js';
 import { useToast } from '../context.jsx';
 
@@ -19,6 +19,7 @@ export default function ServeModal({ playlist: initialPlaylist, onClose }) {
   const [copied,   setCopied]   = useState('');
   const [regen,    setRegen]    = useState(false);
   const [regenCombined, setRegenCombined] = useState(false);
+  const [tests, setTests] = useState({});
 
   const base = window.location.origin;
 
@@ -35,6 +36,16 @@ export default function ServeModal({ playlist: initialPlaylist, onClose }) {
       navigator.clipboard.writeText(text).then(done).catch(() => fallbackCopy(text, done));
     } else {
       fallbackCopy(text, done);
+    }
+  };
+
+  const testUrl = async (key, url, type) => {
+    setTests(current => ({ ...current, [key]: { loading: true } }));
+    try {
+      const result = await api.validateUrl(url, type);
+      setTests(current => ({ ...current, [key]: result }));
+    } catch (e) {
+      setTests(current => ({ ...current, [key]: { loading: false, reachable: false, warnings: [e.message] } }));
     }
   };
 
@@ -78,11 +89,15 @@ export default function ServeModal({ playlist: initialPlaylist, onClose }) {
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
             <p style={{ fontWeight: 600, fontSize: 13 }}>Direct M3U</p>
             <p className="text-xs text-muted">For players that accept a raw M3U URL. Use Combined M3U to include all of your playlists in one URL</p>
-            <UrlRow label="M3U playlist" url={m3uUrl} copied={copied === 'm3u'} onCopy={() => copy(m3uUrl, 'm3u')} />
+            <UrlRow label="M3U playlist" url={m3uUrl} type="m3u" testKey="m3u" test={tests.m3u} onTest={testUrl} copied={copied === 'm3u'} onCopy={() => copy(m3uUrl, 'm3u')} />
             {combinedM3uUrl && (
               <UrlRow
                 label="Combined M3U"
                 url={combinedM3uUrl}
+                type="m3u"
+                testKey="combined-m3u"
+                test={tests['combined-m3u']}
+                onTest={testUrl}
                 copied={copied === 'combined-m3u'}
                 onCopy={() => copy(combinedM3uUrl, 'combined-m3u')}
                 action={
@@ -92,7 +107,7 @@ export default function ServeModal({ playlist: initialPlaylist, onClose }) {
                 }
               />
             )}
-            <UrlRow label="EPG (XMLTV)"  url={epgUrl} copied={copied === 'epg'} onCopy={() => copy(epgUrl, 'epg')} />
+            <UrlRow label="EPG (XMLTV)" url={epgUrl} type="xmltv" testKey="epg" test={tests.epg} onTest={testUrl} copied={copied === 'epg'} onCopy={() => copy(epgUrl, 'epg')} />
           </div>
 
           <div className="divider" style={{ margin: '4px 0' }} />
@@ -107,8 +122,8 @@ export default function ServeModal({ playlist: initialPlaylist, onClose }) {
               <CredBox label="Password" value={playlist.xtream_pass}  copyKey="xpass"   copied={copied} onCopy={copy} />
             </div>
 
-            <UrlRow label="M3U (Xtream format)" url={xtreamM3uUrl} copied={copied === 'xm3u'} onCopy={() => copy(xtreamM3uUrl, 'xm3u')} />
-            <UrlRow label="EPG (Xtream format)" url={xtreamEpgUrl} copied={copied === 'xepg'} onCopy={() => copy(xtreamEpgUrl, 'xepg')} />
+            <UrlRow label="M3U (Xtream format)" url={xtreamM3uUrl} type="m3u" testKey="xm3u" test={tests.xm3u} onTest={testUrl} copied={copied === 'xm3u'} onCopy={() => copy(xtreamM3uUrl, 'xm3u')} />
+            <UrlRow label="EPG (Xtream format)" url={xtreamEpgUrl} type="xmltv" testKey="xepg" test={tests.xepg} onTest={testUrl} copied={copied === 'xepg'} onCopy={() => copy(xtreamEpgUrl, 'xepg')} />
 
             <div style={{ background: 'var(--surface2)', borderRadius: 8, padding: '10px 12px', fontSize: 12, color: 'var(--muted)', lineHeight: 1.6 }}>
               <strong style={{ color: 'var(--text)', display: 'block', marginBottom: 4 }}>TiviMate setup</strong>
@@ -155,18 +170,35 @@ function CredBox({ label, value, copyKey, copied, onCopy }) {
   );
 }
 
-function UrlRow({ label, url, copied, onCopy, action }) {
+function UrlRow({ label, url, copied, onCopy, action, type, testKey, test, onTest }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
         <span className="text-xs text-muted" style={{ fontWeight: 500 }}>{label}</span>
-        {action}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          {action}
+          <button className="btn btn-sm" onClick={() => onTest(testKey, url, type)} disabled={test?.loading}>
+            {test?.loading ? 'Testing…' : 'Test'}
+          </button>
+        </div>
       </div>
       <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
         <input className="input mono" value={url} readOnly style={{ flex: 1, fontSize: 11 }} onClick={e => e.target.select()} />
         <button className="btn btn-sm btn-icon" onClick={onCopy} title="Copy"><Copy size={13} /></button>
         <a href={url} target="_blank" rel="noreferrer" className="btn btn-sm btn-icon"><ExternalLink size={13} /></a>
       </div>
+      {test && !test.loading && (
+        <div style={{ fontSize: 11, lineHeight: 1.45, paddingLeft: 2 }}>
+          <div className={test.reachable ? 'text-green' : 'text-red'}>
+            {test.reachable ? <Check size={12} /> : <X size={12} />} {test.reachable ? 'Reachable' : 'Unreachable'}
+            {test.contentType && <span className="text-muted"> · {test.contentType}</span>}
+          </div>
+          {test.reachable && <div className={test.looksValid ? 'text-green' : 'text-red'}>
+            {test.looksValid ? '✓ Content looks valid' : '✗ Content type/content validation failed'}
+          </div>}
+          {test.warnings?.map((warning, index) => <div className="text-red" key={index}>⚠ {warning}</div>)}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

Add a backend endpoint and frontend UI to validate generated M3U/XMLTV URLs before copying them into downstream apps (Plex, Jellyfin, Channels DVR, etc.).

Fixes #52

## Backend

- New `POST /api/serve/validate-url` endpoint
  - Accepts `{ url, type }` (type: \`m3u\` or \`xmltv\`, auto-detected from path if omitted)
  - Checks HTTP reachability, validates response content (#EXTM3U for M3U, <tv> for XMLTV)
  - Warns if URL uses localhost/127.0.0.1/::1 (unreachable outside container)
  - Returns `{ url, reachable, contentType, looksValid, warnings[] }`

## Frontend

- [Test] button added next to every generated URL in the Serve modal
- Inline results show:
  - Green checkmark / red X with "Reachable" / "Unreachable"
  - Content type hint
  - Content validation pass/fail
  - Warnings (localhost, etc.)
- Works for: Direct M3U, Combined M3U, EPG, Xtream M3U, Xtream EPG

## Tests

- `backend/test/serve-validation.test.js` with 3 subtests:
  - Validates reachable M3U with loopback warning
  - Validates XMLTV content and flags invalid M3U
  - Reports failed HTTP checks and rejects missing URLs
- All 12 backend tests pass (9 existing + 3 new)
- Frontend builds cleanly

## Verification

- [x] Backend tests: 12/12 pass
- [x] Frontend build: vite build succeeds
- [x] No dependency versions changed
- [x] No Docker changes
- [x] No production instance modified