### PR TITLE
feat: add Home Assistant status/health integration endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,40 @@ Commercial licenses are available separately for organizations that want to use,
 
 ---
 
+## Home Assistant Integration
+
+Stationarr provides an unauthenticated status summary endpoint for Home Assistant and other monitoring tools:
+
+```sh
+curl http://your-stationarr-host/api/status/summary
+```
+
+Example Home Assistant REST sensors:
+
+```yaml
+rest:
+  - resource: http://your-stationarr-host/api/status/summary
+    scan_interval: 300
+    sensor:
+      - name: Stationarr Status
+        value_template: "{{ value_json.status }}"
+      - name: Stationarr Version
+        value_template: "{{ value_json.version }}"
+      - name: Stationarr Playlists
+        value_template: "{{ value_json.playlists }}"
+        unit_of_measurement: playlists
+      - name: Stationarr Channels
+        value_template: "{{ value_json.channels }}"
+        unit_of_measurement: channels
+      - name: Stationarr EPG Programmes
+        value_template: "{{ value_json.epg_programmes }}"
+        unit_of_measurement: programmes
+```
+
+The endpoint is intentionally unauthenticated so Home Assistant can poll it without a JWT.
+
+---
+
 ## Contributing
 
 PRs welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -5,6 +5,7 @@ const path      = require('path');
 const fs        = require('fs');
 const rateLimit = require('express-rate-limit');
 const logger = require('./logger');
+const db = require('./db');
 
 function getPackageVersion() {
   const packagePaths = [
@@ -58,6 +59,32 @@ app.use('/api/logs',      require('./routes/logs'));
 app.use('/', require('./routes/xtream'));
 
 app.get('/api/health', (_req, res) => res.json({ ok: true, version }));
+
+// Public status summary for monitoring integrations such as Home Assistant.
+app.get('/api/status/summary', (_req, res) => {
+  try {
+    const count = (table) => db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get().count;
+    const summary = {
+      status: 'ok',
+      version,
+      users: count('users'),
+      playlists: count('playlists'),
+      channels: count('channels'),
+      epg_sources: count('epg_sources'),
+      epg_channels: count('epg_channels'),
+      guide_programmes: count('guide_programmes'),
+      scraper_channels: count('scraper_channels'),
+      last_refreshed: db.prepare('SELECT MAX(last_refreshed) AS last_refreshed FROM playlists').get().last_refreshed,
+      last_fetched: db.prepare('SELECT MAX(last_fetched) AS last_fetched FROM epg_sources').get().last_fetched,
+      last_error: null,
+    };
+    // Keep the HA-facing name explicit while retaining the database table name.
+    summary.epg_programmes = summary.guide_programmes;
+    res.json(summary);
+  } catch (error) {
+    res.json({ status: 'degraded', version, last_error: error.message });
+  }
+});
 
 // Serve frontend (production)
 const DIST = path.join(__dirname, '../public');

--- a/backend/test/status-summary.test.js
+++ b/backend/test/status-summary.test.js
@@ -1,0 +1,73 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const fetch = require('node-fetch');
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stationarr-status-test-'));
+process.env.DATA_DIR = dataDir;
+process.env.APP_VERSION = 'test-version';
+process.env.NODE_ENV = 'test';
+
+const db = require('../src/db');
+const app = require('../src/index');
+
+const user = db.prepare('INSERT INTO users (username,email,password) VALUES (?,?,?)')
+  .run('status-test', 'status@example.test', 'unused');
+const userId = Number(user.lastInsertRowid);
+const playlist = db.prepare('INSERT INTO playlists (user_id,name,slug,last_refreshed) VALUES (?,?,?,?)')
+  .run(userId, 'Test playlist', 'status-playlist', '2026-09-01 10:00:00');
+const playlistId = Number(playlist.lastInsertRowid);
+db.prepare('INSERT INTO channels (playlist_id,name,url) VALUES (?,?,?)')
+  .run(playlistId, 'One', 'http://example.test/one');
+db.prepare('INSERT INTO channels (playlist_id,name,url) VALUES (?,?,?)')
+  .run(playlistId, 'Two', 'http://example.test/two');
+const source = db.prepare('INSERT INTO epg_sources (user_id,name,last_fetched,programme_count) VALUES (?,?,?,?)')
+  .run(userId, 'Test EPG', '2026-09-01 11:00:00', 3);
+const sourceId = Number(source.lastInsertRowid);
+db.prepare('INSERT INTO epg_channels (source_id,tvg_id,name) VALUES (?,?,?)')
+  .run(sourceId, 'one', 'One');
+for (let i = 0; i < 3; i++) {
+  db.prepare('INSERT INTO guide_programmes (source_id,epg_id,start,stop,title) VALUES (?,?,?,?,?)')
+    .run(sourceId, 'one', `202609010${i}0000`, `202609010${i + 1}0000`, `Show ${i}`);
+}
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  server = app.listen(0, '127.0.0.1');
+  await new Promise((resolve) => server.once('listening', resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+test.after(async () => {
+  await new Promise((resolve) => server.close(resolve));
+  db.close();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+test('returns the unauthenticated status summary with correct fields and counts', async () => {
+  const response = await fetch(`${baseUrl}/api/status/summary`);
+  assert.equal(response.status, 200);
+  const summary = await response.json();
+
+  for (const field of [
+    'status', 'version', 'users', 'playlists', 'channels', 'epg_sources',
+    'epg_channels', 'guide_programmes', 'epg_programmes', 'scraper_channels',
+    'last_refreshed', 'last_fetched', 'last_error',
+  ]) assert.ok(Object.hasOwn(summary, field), `missing ${field}`);
+
+  assert.equal(summary.status, 'ok');
+  assert.equal(summary.version, 'test-version');
+  assert.equal(summary.users, 1);
+  assert.equal(summary.playlists, 1);
+  assert.equal(summary.channels, 2);
+  assert.equal(summary.epg_sources, 1);
+  assert.equal(summary.epg_channels, 1);
+  assert.equal(summary.guide_programmes, 3);
+  assert.equal(summary.epg_programmes, 3);
+  assert.equal(summary.scraper_channels, 0);
+  assert.equal(summary.last_error, null);
+});

--- a/docs/API.md
+++ b/docs/API.md
@@ -235,6 +235,33 @@ Common status codes: `400` bad input, `401` unauthenticated, `403` forbidden, `4
 
 ---
 
+## Public status
+
+### GET /status/summary
+Returns an unauthenticated status and inventory summary for monitoring integrations such as Home Assistant. It returns HTTP `200` even when the application is degraded, so monitoring clients can read `status` and `last_error`.
+
+```json
+{
+  "status": "ok",
+  "version": "1.2.2",
+  "users": 3,
+  "playlists": 7,
+  "channels": 12400,
+  "epg_sources": 4,
+  "epg_channels": 12000,
+  "guide_programmes": 85000,
+  "epg_programmes": 85000,
+  "scraper_channels": 12,
+  "last_refreshed": "2026-09-01 12:00:00",
+  "last_fetched": "2026-09-01 12:05:00",
+  "last_error": null
+}
+```
+
+`status` is `ok` when all database queries succeed and `degraded` when a query fails. The first version does not check GitHub for update information.
+
+---
+
 ## Xtream Codes API (public, no JWT)
 
 These endpoints are mounted at the root and implement the Xtream Codes protocol.


### PR DESCRIPTION
## What

Add a lightweight unauthenticated status summary endpoint for Home Assistant and other monitoring tools. Closes #43.

## Backend

- New `GET /api/status/summary` — unauthenticated, returns:
  - `status` — `"ok"` or `"degraded"`
  - `version` — app version string
  - `users`, `playlists`, `channels`, `epg_sources`, `epg_channels`, `guide_programmes`/`epg_programmes`, `scraper_channels`
  - `last_refreshed` — most recent playlist refresh
  - `last_fetched` — most recent EPG fetch
  - `last_error` — `null` or error message
- On DB query failure, returns `status: "degraded"` with the error message in `last_error`
- No auth required (same as `/api/health`)

## Tests

- `backend/test/status-summary.test.js` — validates all response fields, correct counts, unauthenticated access
- All 10 backend tests pass (9 existing + 1 new)

## Documentation

- `docs/API.md` — new "Public status" section documenting the endpoint and response shape
- `README.md` — new "Home Assistant Integration" section with:
  - `curl` example
  - Home Assistant REST sensor YAML (5 sensors: status, version, playlists, channels, EPG programmes)

## Verification

- [x] Backend tests: 10/10 pass
- [x] Frontend build: vite build succeeds
- [x] No dependency versions changed
- [x] No Docker changes
- [x] No production instance modified