### PR TITLE
feat: add EPG match confidence and explanation details

### DIFF
--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -192,6 +192,15 @@ const chCols2 = db.prepare("PRAGMA table_info(channels)").all().map(c => c.name)
 if (!chCols2.includes('backup_epg_id')) {
   db.exec("ALTER TABLE channels ADD COLUMN backup_epg_id TEXT NOT NULL DEFAULT ''");
 }
+if (!chCols2.includes('auto_match_confidence')) {
+  db.exec("ALTER TABLE channels ADD COLUMN auto_match_confidence TEXT");
+}
+if (!chCols2.includes('auto_match_reason')) {
+  db.exec("ALTER TABLE channels ADD COLUMN auto_match_reason TEXT");
+}
+// Preserve an explanation for channels that already had an EPG assignment
+// before match confidence was introduced.
+db.exec("UPDATE channels SET auto_match_confidence='Manual', auto_match_reason='Manually assigned' WHERE epg_id != '' AND auto_match_confidence IS NULL");
 
 if (!epgCols3.includes('guide_index_status')) db.exec("ALTER TABLE epg_sources ADD COLUMN guide_index_status TEXT DEFAULT 'idle'");
 if (!epgCols3.includes('guide_index_updated')) db.exec("ALTER TABLE epg_sources ADD COLUMN guide_index_updated TEXT");

--- a/backend/src/routes/channels.js
+++ b/backend/src/routes/channels.js
@@ -95,6 +95,13 @@ router.put('/:id', (req, res) => {
   fields.forEach(f => { if (req.body[f] !== undefined) updates[f] = req.body[f]; });
   if (!Object.keys(updates).length) return res.json(ch);
 
+  // An EPG assignment made through the channel editor is manual. Clear stale
+  // match metadata when the assignment is removed.
+  if (Object.prototype.hasOwnProperty.call(updates, 'epg_id') && updates.epg_id !== ch.epg_id) {
+    updates.auto_match_confidence = updates.epg_id ? 'Manual' : null;
+    updates.auto_match_reason = updates.epg_id ? 'Manually assigned' : null;
+  }
+
   const set = Object.keys(updates).map(k => `${k}=@${k}`).join(', ');
   db.prepare(`UPDATE channels SET ${set} WHERE id=@id`).run({ ...updates, id: ch.id });
   res.json(db.prepare('SELECT * FROM channels WHERE id = ?').get(ch.id));
@@ -166,7 +173,8 @@ router.post('/bulk', (req, res) => {
   } else if (action === 'set_group' && value) {
     db.prepare(`UPDATE channels SET grp=? WHERE ${whereSql}`).run(value, ...whereParams);
   } else if (action === 'set_epg_id' && value !== undefined) {
-    db.prepare(`UPDATE channels SET epg_id=? WHERE ${whereSql}`).run(value, ...whereParams);
+    db.prepare(`UPDATE channels SET epg_id=?, auto_match_confidence=?, auto_match_reason=? WHERE ${whereSql}`)
+      .run(value, value ? 'Manual' : null, value ? 'Manually assigned' : null, ...whereParams);
   } else {
     return res.status(400).json({ error: 'Unknown action' });
   }

--- a/backend/src/routes/epg.js
+++ b/backend/src/routes/epg.js
@@ -309,6 +309,21 @@ router.get('/programmes', async (req, res) => {
   res.json(sorted);
 });
 
+// GET /api/epg/match-details?playlist_id=X — explain each channel's EPG match
+router.get('/match-details', (req, res) => {
+  const { playlist_id } = req.query;
+  if (!playlist_id) return res.status(400).json({ error: 'playlist_id required' });
+  const playlist = db.prepare('SELECT id FROM playlists WHERE id=? AND user_id=?').get(playlist_id, req.user.id);
+  if (!playlist) return res.status(404).json({ error: 'Not found' });
+
+  const results = db.prepare(`
+    SELECT id AS channel_id, name, epg_id, auto_match_confidence AS confidence,
+           auto_match_reason AS reason
+    FROM channels WHERE playlist_id=? ORDER BY ord ASC, id ASC
+  `).all(playlist_id);
+  res.json({ results });
+});
+
 // POST /api/epg/auto-match — smarter fuzzy matching
 router.post('/auto-match', (req, res) => {
   const { playlist_id, match_logos } = req.body;
@@ -331,50 +346,97 @@ router.post('/auto-match', (req, res) => {
         WHERE es.user_id = ?
       `).all(req.user.id);
 
-  if (!epgChannels.length) return res.json({ matched: 0, logo_matched: 0, unmatched: 0 });
+  const channels = db.prepare('SELECT * FROM channels WHERE playlist_id = ?').all(playlist_id);
+  if (!epgChannels.length) return res.json({
+    matched: 0, logo_matched: 0, unmatched: channels.filter(ch => !ch.epg_id).length,
+    results: channels.map(ch => ({ channel_id: ch.id, name: ch.name, epg_id: ch.epg_id || '',
+      confidence: ch.auto_match_confidence || (ch.epg_id ? 'Manual' : null),
+      reason: ch.auto_match_reason || (ch.epg_id ? 'Manually assigned' : null) }))
+  });
 
   // Build lookup maps — exact id, exact normalized name, fuzzy name
   const byId    = new Map(epgChannels.map(c => [c.tvg_id.toLowerCase(), c]));
   const byNorm  = new Map(epgChannels.map(c => [normalize(c.name), c]));
+  const byCountry = new Map(epgChannels.filter(c => hasCountry(c.name)).map(c => [nameCountryKey(c.name), c]));
   const byFuzzy = new Map(epgChannels.map(c => [fuzzy(c.name), c]));
 
-  const channels = db.prepare('SELECT * FROM channels WHERE playlist_id = ?').all(playlist_id);
-
   let matched = 0, logo_matched = 0, unmatched = 0;
-  const updateEpg  = db.prepare('UPDATE channels SET epg_id=? WHERE id=?');
+  const results = [];
+  const updateEpg  = db.prepare('UPDATE channels SET epg_id=?, auto_match_confidence=?, auto_match_reason=? WHERE id=?');
   const updateLogo = db.prepare('UPDATE channels SET tvg_logo=? WHERE id=?');
 
   db.transaction(() => {
     for (const ch of channels) {
       const existingId = ch.epg_id || ch.tvg_id;
-
-      const epg =
-        // 1. Exact tvg-id match
-        byId.get(existingId.toLowerCase()) ||
-        byId.get(ch.tvg_id.toLowerCase()) ||
-        // 2. Exact normalized name
-        byNorm.get(normalize(ch.name)) ||
-        byNorm.get(normalize(ch.tvg_name)) ||
-        // 3. Fuzzy name (strips HD, SD, +1, country suffix, punctuation)
-        byFuzzy.get(fuzzy(ch.name)) ||
-        byFuzzy.get(fuzzy(ch.tvg_name));
+      let epg;
+      let match;
+      // 1. Exact tvg-id match
+      epg = byId.get(String(existingId).toLowerCase()) || byId.get(String(ch.tvg_id).toLowerCase());
+      if (epg) match = matchConfidence('id');
+      // 2. Exact normalized name
+      if (!epg) {
+        epg = byNorm.get(normalize(ch.name)) || byNorm.get(normalize(ch.tvg_name));
+        if (epg) match = matchConfidence('normalized-name');
+      }
+      // 3. Name + country match (country is conventionally a trailing code/name)
+      if (!epg && hasCountry(ch.name || ch.tvg_name)) {
+        epg = byCountry.get(nameCountryKey(ch.name)) || byCountry.get(nameCountryKey(ch.tvg_name));
+        if (epg) match = matchConfidence('country');
+      }
+      // 4. Fuzzy name (strips HD, SD, +1, country suffix, punctuation)
+      if (!epg) {
+        epg = byFuzzy.get(fuzzy(ch.name)) || byFuzzy.get(fuzzy(ch.tvg_name));
+        if (epg) match = matchConfidence('fuzzy');
+      }
 
       if (epg) {
-        if (!ch.epg_id) { updateEpg.run(epg.tvg_id, ch.id); matched++; }
+        if (!ch.epg_id) { updateEpg.run(epg.tvg_id, match.confidence, match.reason, ch.id); matched++; }
         if (match_logos && !ch.tvg_logo && epg.icon) { updateLogo.run(epg.icon, ch.id); logo_matched++; }
       } else if (!ch.epg_id) {
         unmatched++;
       }
+
+      const current = db.prepare('SELECT epg_id, auto_match_confidence, auto_match_reason FROM channels WHERE id=?').get(ch.id);
+      results.push({ channel_id: ch.id, name: ch.name, epg_id: current.epg_id || '',
+        confidence: current.auto_match_confidence || (current.epg_id ? 'Manual' : null),
+        reason: current.auto_match_reason || (current.epg_id ? 'Manually assigned' : null) });
     }
   })();
 
-  res.json({ matched, logo_matched, unmatched });
+  res.json({ matched, logo_matched, unmatched, results });
 });
 
 // ── Helpers ───────────────────────────────────────────────────────
 
 function normalize(s) {
-  return s.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function matchConfidence(type) {
+  if (!type) return null;
+  const matches = {
+    id: ['High', 'Matched by exact tvg-id'],
+    'normalized-name': ['High', 'Matched by normalized channel name'],
+    country: ['Medium', 'Matched by name and country'],
+    fuzzy: ['Low', 'Matched by fuzzy name similarity'],
+  };
+  const [confidence, reason] = matches[type];
+  return { confidence, reason };
+}
+
+function countryCode(s) {
+  const value = String(s || '').trim();
+  const match = value.match(/(?:[\s([-])(US|UK|CA|AU|DE|FR|ES|IT|IN|MX|JP|CN|BR|PT|NL|BE|AT|CH|IE|NZ|ZA|PH|SE|NO|DK|FI|PL|TR|GR|IL|RU|UA|AR|CL|CO)\s*[\])]?$|(?:[\s-])(USA|Canada|Australia|Germany|France|Spain|Italy|India|Mexico)\s*$/i);
+  return match ? (match[1] || match[2]).toLowerCase() : '';
+}
+
+function hasCountry(s) { return !!countryCode(s); }
+
+function nameCountryKey(s) {
+  const value = String(s || '').trim();
+  const country = countryCode(value);
+  const base = country ? value.replace(/(?:[\s([-])(?:US|UK|CA|AU|DE|FR|ES|IT|IN|MX|JP|CN|BR|PT|NL|BE|AT|CH|IE|NZ|ZA|PH|SE|NO|DK|FI|PL|TR|GR|IL|RU|UA|AR|CL|CO)\s*[\])]?$|(?:[\s-])(?:USA|Canada|Australia|Germany|France|Spain|Italy|India|Mexico)\s*$/i, '') : value;
+  return `${fuzzy(base)}|${country}`;
 }
 
 function fuzzy(s) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -126,6 +126,7 @@ export const epg = {
   upload:     (id, file)  => upload('POST', `/epg/${id}/upload`, file, file.type || 'application/octet-stream'),
   refresh:    (id)        => post(`/epg/${id}/refresh`),
   autoMatch:  (body)      => post('/epg/auto-match',   body),
+  matchDetails: (playlistId) => get(`/epg/match-details?playlist_id=${encodeURIComponent(playlistId)}`),
   clearCache:  (id)        => del(`/epg/${id}/cache`),
   reorder:    (body)       => post('/epg/reorder', body),
   programmes: (epgId)     => get(`/epg/programmes?epg_id=${encodeURIComponent(epgId)}`),

--- a/frontend/src/components/ChannelPanel.jsx
+++ b/frontend/src/components/ChannelPanel.jsx
@@ -127,7 +127,12 @@ export default function ChannelPanel({ channel, epgChannels, epgSources = [], on
               epgSources={epgSources}
               value={form.epg_id || ''}
               onChange={(val) => { setForm(f => ({ ...f, epg_id: val })); setSaved(false); }}
-            />
+              />
+            {form.auto_match_confidence && (
+              <div style={{ marginTop: 6, fontSize: 11, color: 'var(--muted)' }}>
+                <strong>{form.auto_match_confidence} confidence</strong> · {form.auto_match_reason}
+              </div>
+            )}
           </div>
 
           <div className="field">

--- a/frontend/src/components/ChannelTable.jsx
+++ b/frontend/src/components/ChannelTable.jsx
@@ -243,6 +243,8 @@ export default function ChannelTable({
                 <th>Channel</th>
                 <th style={{ width: 160 }}>Group</th>
                 <th style={{ width: 130 }}>EPG</th>
+                <th style={{ width: 90 }}>Confidence</th>
+                <th style={{ width: 210 }}>Match reason</th>
                 <th style={{ width: 70, textAlign: 'center' }}>Status</th>
                 <th style={{ width: 40 }} />
               </tr>
@@ -250,7 +252,7 @@ export default function ChannelTable({
             <tbody>
               {/* Spacer row above visible range */}
               {visibleStart > 0 && (
-                <tr><td colSpan={7} style={{ height: visibleStart * ROW_H, padding: 0, border: 'none' }} /></tr>
+                <tr><td colSpan={9} style={{ height: visibleStart * ROW_H, padding: 0, border: 'none' }} /></tr>
               )}
               {displayChannels.slice(visibleStart, visibleStart + visibleCount).map((ch, i) => {
                 const idx = visibleStart + i;
@@ -292,6 +294,8 @@ export default function ChannelTable({
                       : <span className="text-faint text-sm">—</span>
                     }
                   </td>
+                  <td><ConfidenceBadge confidence={ch.auto_match_confidence} /></td>
+                  <td><span className="text-xs text-muted" title={ch.auto_match_reason || ''}>{ch.auto_match_reason || '—'}</span></td>
                   <td style={{ textAlign: 'center' }} onClick={e => e.stopPropagation()}>
                     <button
                       className="btn btn-ghost btn-icon btn-sm"
@@ -313,7 +317,7 @@ export default function ChannelTable({
               })}
               {/* Spacer row below visible range */}
               {visibleStart + visibleCount < displayChannels.length && (
-                <tr><td colSpan={7} style={{ height: (displayChannels.length - visibleStart - visibleCount) * ROW_H, padding: 0, border: 'none' }} /></tr>
+                <tr><td colSpan={9} style={{ height: (displayChannels.length - visibleStart - visibleCount) * ROW_H, padding: 0, border: 'none' }} /></tr>
               )}
             </tbody>
           </table>
@@ -340,6 +344,14 @@ export default function ChannelTable({
       )}
     </div>
   );
+}
+
+function ConfidenceBadge({ confidence }) {
+  if (!confidence) return <span className="text-faint text-xs">—</span>;
+  const className = confidence === 'High' ? 'badge-green'
+    : confidence === 'Medium' ? 'badge-yellow'
+    : confidence === 'Low' ? 'badge-red' : 'badge-muted';
+  return <span className={`badge ${className}`} title={`${confidence} confidence`}>{confidence}</span>;
 }
 
 function LogoThumb({ src }) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -137,6 +137,8 @@ select.input { cursor: pointer; }
   border-radius: 20px;
 }
 .badge-green  { background: var(--green-bg); color: var(--green); }
+.badge-yellow { background: color-mix(in oklab, var(--yellow) 18%, var(--surface2)); color: var(--yellow); }
+.badge-red    { background: var(--red-bg); color: var(--red); }
 .badge-blue   { background: var(--blue-bg);  color: var(--blue);  }
 .badge-muted  { background: var(--surface2); color: var(--muted); }
 .badge-accent { background: var(--accent-dim); color: var(--accent); }

--- a/frontend/src/pages/Editor.jsx
+++ b/frontend/src/pages/Editor.jsx
@@ -104,7 +104,16 @@ export default function Editor() {
   const [showMatchPicker, setShowMatchPicker] = useState(false);
   const autoMatch = useCallback(async (matchLogos, sourceId) => {
     if (epgSources.length > 1 && sourceId === null) return setShowMatchPicker({ matchLogos });
-    try { const res = await epgApi.autoMatch({ playlist_id: id, match_logos: matchLogos, source_id: sourceId }); toast(`Matched ${res.matched} channels`, 'success'); await loadChannels(); } catch (e) { toast(e.message, 'error'); }
+    try {
+      const res = await epgApi.autoMatch({ playlist_id: id, match_logos: matchLogos, source_id: sourceId });
+      const breakdown = (res.results || []).reduce((counts, item) => {
+        if (item.confidence) counts[item.confidence] = (counts[item.confidence] || 0) + 1;
+        return counts;
+      }, {});
+      const summary = ['High', 'Medium', 'Low', 'Manual'].filter(k => breakdown[k]).map(k => `${breakdown[k]} ${k}`).join(' · ');
+      toast(`Matched ${res.matched} channels${summary ? ` (${summary})` : ''}`, 'success');
+      await loadChannels();
+    } catch (e) { toast(e.message, 'error'); }
   }, [id, epgSources, loadChannels]);
   const onEpgSourceChange = useCallback(async () => {
     const sources = await epgApi.list(); setEpgSources(sources); const loaded = sources.filter(s => s.channel_count > 0); const results = await Promise.all(loaded.map(s => epgApi.channels(s.id))); setAllEpgCh(results.flat());


### PR DESCRIPTION
## Summary

Enhances the auto-match endpoint to assign a **confidence level** and **human-readable explanation** for each channel-to-EPG match, displayed directly in the channel table.

### Backend
- **4-level matching:** exact tvg-id (High), normalized name (High), name+country (Medium), fuzzy name (Low)
- New columns `auto_match_confidence` / `auto_match_reason` on channels table with safe migration
- Existing EPG assignments backfilled as `Manual / Manually assigned`
- `POST /api/epg/auto-match` now returns per-channel match results alongside legacy counts
- New `GET /api/epg/match-details` for match metadata
- Bulk and individual channel EPG updates set confidence to Manual

### Frontend
- **ConfidenceBadge** component: green=High, yellow=Medium, red=Low, gray=Manual
- Two new table columns: Confidence badge and Match reason
- Channel panel shows confidence/reason for current EPG assignment
- Auto-match toast shows confidence breakdown summary

Closes #55